### PR TITLE
Add ability to force futures

### DIFF
--- a/BrightFuturesTests/BrightFuturesTests.swift
+++ b/BrightFuturesTests/BrightFuturesTests.swift
@@ -379,14 +379,14 @@ class BrightFuturesTests: XCTestCase {
     }
 
     func testForcedFuture() {
-      var x = 10
-      let f: Future<Void> = future { _ in
-        NSThread.sleepForTimeInterval(0.5)
-        x = 3
-        return ()
-      }
-      f.forced
-      XCTAssertEqual(x, 3)
+        var x = 10
+        let f: Future<Void> = future { _ in
+            NSThread.sleepForTimeInterval(0.5)
+            x = 3
+            return ()
+        }
+        f.forced()
+        XCTAssertEqual(x, 3)
     }
  
     // Creates a lot of futures and adds completion blocks concurrently, which should all fire


### PR DESCRIPTION
Similar to Scala's

``` scala
Await.result(awaitable: Awaitable[T], atMost: Duration)
```

However, I think it is more useful to make this available as a method on the future directly (similar to Java Future's get() method)

If you're wondering where the name `force` comes from: `force` is used rather than `wait` in most PL theory and is the name of the Haskell function for forcing (awaiting) futures.
