### PR TITLE
Refactor to utilize Swift's powerful enums

### DIFF
--- a/BrightFutures/Future.swift
+++ b/BrightFutures/Future.swift
@@ -35,7 +35,7 @@ func future<T>(context c: ExecutionContext = QueueExecutionContext.global, task:
             promise.success(result!)
         }
     }
-    
+
     return promise.future
 }
 
@@ -55,21 +55,21 @@ class Future<T> {
     
     let q = Queue()
     
-    var result = TaskResult<T>()
+    var result: TaskState<T> = .Pending
     
     var value: T? {
-        switch result.state {
-        case .Success:
-            return result.value as? T
+        switch result {
+        case .Done(.Success(let v)):
+            return v()
         default:
             return nil
         }
     }
     
     var error: NSError? {
-        switch result.state {
-        case .Failure:
-            return result.error
+        switch result {
+        case .Done(.Failure(let e)):
+            return e
         default:
             return nil
         }
@@ -92,34 +92,35 @@ class Future<T> {
 
     class func succeeded(value: T) -> Future<T> {
         let res = Future<T>();
-        res.result = TaskResult(value: value)
+        res.result = .Done(.Success(value))
         
         return res
     }
     
     class func failed(error: NSError) -> Future<T> {
         let res = Future<T>();
-        res.result = TaskResult(error: error)
+        res.result = .Done(.Failure(error))
         
         return res
     }
     
     // TODO: private
-    func complete(result: TaskResult<T>) {
+    func complete(result: TaskState<T>) {
         if !tryComplete(result) {
             
         }
     }
     
     // TODO: private
-    func tryComplete(result: TaskResult<T>) -> Bool {
-        assert(result.value || result.error)
-        
-        switch result.state {
-        case State.Success:
-            return self.trySuccess(result.value!)
-        default:
-            return self.tryError(result.error!)
+    func tryComplete(result: TaskState<T>) -> Bool {
+        switch result {
+        case .Done(.Success(let v)):
+            return self.trySuccess(v())
+        case .Done(.Failure(let e)):
+            return self.tryError(e)
+        case .Pending:
+            assert(false)
+            return false
         }
     }
     
@@ -131,11 +132,14 @@ class Future<T> {
     // TODO: private
     func trySuccess(value: T) -> Bool {
         return (q.sync {
-            if self.result.state != .Pending {
+            switch (self.result) {
+            case .Pending:
+                break
+            case .Done(_):
                 return false;
             }
-            
-            self.result = TaskResult(value: value)
+
+            self.result = .Done(.Success(value))
             self.runCallbacks()
             return true;
         })!;
@@ -151,11 +155,14 @@ class Future<T> {
     // TODO: private
     func tryError(error: NSError) -> Bool {
         return (q.sync {
-            if self.result.state != .Pending {
-                return false;
+            switch (self.result) {
+            case .Pending:
+                break
+            case .Done(_):
+                return false
             }
-            
-            self.result = TaskResult(error: error)
+
+            self.result = .Done(.Failure(error))
             self.runCallbacks()
             return true;
         })!;
@@ -168,19 +175,26 @@ class Future<T> {
     func onComplete(context c: ExecutionContext, callback: CompletionCallback) {
         q.sync {
             let wrappedCallback : Future<T> -> () = { future in
-                c.execute {
-                    callback(result: self.result)
+                c.execute { _ in
+                    switch(self.result) {
+                    case .Done(let res):
+                        callback(result: res)
+                    case .Pending:
+                        assert(false)
+                        break
+                    }
                 }
             }
-            
-            if self.result.state == .Pending {
+
+            switch (self.result) {
+            case .Pending:
                 self.callbacks.append(wrappedCallback)
-            } else {
+            case .Done(_):
                 wrappedCallback(self)
             }
         }
     }
-    
+
     func map<U>(f: T -> U) -> Future<U> {
         return self.map(context: self.defaultCallbackExecutionContext, f)
     }
@@ -189,12 +203,12 @@ class Future<T> {
         let p = Promise<U>()
         
         self.onComplete(context: c, callback: { result in
-            switch result.state {
-            case .Success:
-                p.success(f(result.value!))
+            switch result {
+            case .Success(let v):
+                p.success(f(v()))
                 break;
-            default:
-                p.error(result.error!)
+            case .Failure(let e):
+                p.error(e)
                 break;
             }
         })
@@ -223,8 +237,11 @@ class Future<T> {
     
     func onSuccess(context c: ExecutionContext, callback: SuccessCallback) {
         self.onComplete(context: c) { result in
-            if !result.error {
-                callback(result.value!)
+            switch (result) {
+            case .Success(let v):
+                callback(v())
+            case .Failure(_):
+                break
             }
         }
     }
@@ -235,8 +252,11 @@ class Future<T> {
     
     func onFailure(context c: ExecutionContext, callback: FailureCallback) {
         self.onComplete(context: c) { result in
-            if result.error {
-                callback(result.error!)
+            switch (result) {
+            case .Failure(let e):
+                callback(e)
+            case .Success(_):
+                break
             }
         }
     }
@@ -259,9 +279,10 @@ class Future<T> {
         let p = Promise<T>()
         
         self.onComplete(context: c) { result -> () in
-            if result.error {
-                p.completeWith(task(result.error!))
-            } else {
+            switch (result) {
+            case .Failure(let e):
+                p.completeWith(task(e))
+            case .Success(_):
                 p.completeWith(self)
             }
         }
@@ -272,22 +293,22 @@ class Future<T> {
     func zip<U>(that: Future<U>) -> Future<(T,U)> {
         let p = Promise<(T,U)>()
         self.onComplete { thisResult in
-            switch thisResult.state {
-                case .Success:
+            switch thisResult {
+                case .Success(let thisValue):
                     that.onComplete { thatResult in
-                        switch thatResult.state {
-                        case .Success:
-                            let combinedResult = (thisResult.value!, thatResult.value!)
+                        switch thatResult {
+                        case .Success(let thatValue):
+                            let combinedResult = (thisValue(), thatValue())
                             p.success(combinedResult)
                             break
-                        default:
-                            p.error(thatResult.error!)
+                        case .Failure(let error):
+                            p.error(error)
                             break
                         }
                     }
                     break
-                default:
-                    p.error(thisResult.error!)
+                case .Failure(let error):
+                    p.error(error)
                     break
                 
             }
@@ -300,16 +321,16 @@ class Future<T> {
         let promise = Promise<T>()
         
         self.onComplete { result in
-            switch result.state {
-            case .Success:
-                if p(result.value!) {
+            switch result {
+            case .Success(let v):
+                if p(v()) {
                     promise.completeWith(self)
                 } else {
                     promise.error(NSError(domain: NoSuchElementError, code: 0, userInfo: nil))
                 }
                 break
-            default:
-                promise.error(result.error!)
+            case .Failure(let e):
+                promise.error(e)
                 break
             }
         }
@@ -333,31 +354,13 @@ class Future<T> {
     }
 }
 
-enum State {
-    case Pending, Success, Failure
+enum TaskState<T> {
+    case Pending
+    case Done(TaskResult<T>)
 }
 
-struct TaskResult<T> { // should be generic, but compiler issues prevent this
-    let state: State
-    let value: T?
-    let error: NSError?
-    
-    init() {
-        self.state = .Pending
-        self.value = nil
-        self.error = nil
-    }
-    
-    init(value: T?) {
-        self.state = .Success
-        self.value = value
-        self.error = nil
-    }
-    
-    init (error: NSError) {
-        self.state = .Failure
-        self.value = nil
-        self.error = error
-    }
-    
+enum TaskResult<T> {
+    // workaround for not having nested generic enums yet
+    case Success(@auto_closure () -> T)
+    case Failure(NSError)
 }

--- a/BrightFutures/Promise.swift
+++ b/BrightFutures/Promise.swift
@@ -28,10 +28,11 @@ class Promise<T> {
     
     func completeWith(future: Future<T>) {
         future.onComplete { result in
-            if result.error {
-                self.error(result.error!)
-            } else {
-                self.success(result.value!)
+            switch (result) {
+            case .Success(let v):
+                self.success(v())
+            case .Failure(let e):
+                self.error(e)
             }
         }
     }


### PR DESCRIPTION
TaskResult is now much simpler and safer (also broken up into two enums). We can express the same information without having to do unsafe unboxing of optionals anywhere.

Note: I didn't actually change any of the logic in the code, I just moved unsafe unboxing conditionals to safe pattern matching switch statements.

Depends on #1 (I can rebase this out if you want to except this and not #1)
