### PR TITLE
FlatMap on Futures

### DIFF
--- a/BrightFutures/Future.swift
+++ b/BrightFutures/Future.swift
@@ -197,7 +197,24 @@ class Future<T> {
             }
         }
     }
-    
+
+    func flatMap<U>(f: T -> Future<U>) -> Future<U> {
+        return self.flatMap(context: self.defaultCallbackExecutionContext, f)
+    }
+
+    func flatMap<U>(context c: ExecutionContext, f: T -> Future<U>) -> Future<U> {
+        let p: Promise<U> = Promise()
+        self.onComplete(context: c) { res in
+            switch (res) {
+            case .Failure(let e):
+                p.error(e)
+            case .Success(let v):
+                p.completeWith(f(v))
+            }
+        }
+        return p.future
+    }
+
     func map<U>(f: T -> U) -> Future<U> {
         return self.map(context: self.defaultCallbackExecutionContext, f)
     }
@@ -231,7 +248,7 @@ class Future<T> {
 
         return p.future
     }
-    
+
     func onSuccess(callback: SuccessCallback) {
         self.onSuccess(context: self.defaultCallbackExecutionContext, callback)
     }

--- a/BrightFuturesTests/BrightFuturesTests.swift
+++ b/BrightFuturesTests/BrightFuturesTests.swift
@@ -556,7 +556,23 @@ class BrightFuturesTests: XCTestCase {
 
         self.waitForExpectationsWithTimeout(2, handler: nil)
     }
-    
+
+    func testFlatMap() {
+        let e = self.expectationWithDescription("")
+
+        let finalString = "Greg"
+        let flatMapped: Future<String> = future("Thomas").flatMap { _ in
+            return future(finalString)
+        }
+
+        flatMapped.onSuccess { s in
+            XCTAssertEqual(s, finalString, "strings are not equal")
+            e.fulfill()
+        }
+
+        self.waitForExpectationsWithTimeout(2, handler: nil)
+    }
+ 
     // Creates a lot of futures and adds completion blocks concurrently, which should all fire
     func testStress() {
         let instances = 100;


### PR DESCRIPTION
Works similarly to Scala's flatMap. 
`flatMap(f: T -> Future<U>) -> Future<U>`

We don't need the error parameter because if you want this map to fail you fail the future you return.

Depends on #1 #2 and #3
