### PR TITLE
Fixes for beta5

### DIFF
--- a/BrightFutures/Future.swift
+++ b/BrightFutures/Future.swift
@@ -39,7 +39,7 @@ public func future<T>(context c: ExecutionContext = Queue.global, task: (inout N
     return promise.future
 }
 
-public func future<T>(context c: ExecutionContext = Queue.global, task: @auto_closure () -> T?) -> Future<T> {
+public func future<T>(context c: ExecutionContext = Queue.global, task: @autoclosure () -> T?) -> Future<T> {
     return future(context: c) { error in
         return task()
     }
@@ -136,7 +136,7 @@ public class Future<T> {
     
     func trySuccess(value: T) -> Bool {
         return q.sync {
-            if self.result {
+            if self.result != nil {
                 return false;
             }
             
@@ -153,7 +153,7 @@ public class Future<T> {
     
     func tryError(error: NSError) -> Bool {
         return q.sync {
-            if self.result {
+            if self.result != nil {
                 return false;
             }
             
@@ -205,7 +205,7 @@ public class Future<T> {
                 }
             }
             
-            if !self.result {
+            if self.result == nil {
                 self.callbacks.append(wrappedCallback)
             } else {
                 wrappedCallback(self)

--- a/BrightFutures/FutureUtils.swift
+++ b/BrightFutures/FutureUtils.swift
@@ -54,7 +54,7 @@ public class FutureUtils {
         return self.fold(map(seq, fn), context: c, zero: [U](), op: { (list: [U], elem: U) -> [U] in
             // this should be even nicer in beta 5
             var l = list
-            l += elem
+            l.append(elem)
             return l
         })
     }

--- a/BrightFuturesTests/BrightFuturesTests.swift
+++ b/BrightFuturesTests/BrightFuturesTests.swift
@@ -224,7 +224,7 @@ class BrightFuturesTests: XCTestCase {
         p.future.onComplete { result in
             switch result {
             case .Success(let val):
-                XCTAssert(55 == val)
+                XCTAssert(Int(55) == val)
             case .Failure(_):
                 XCTAssert(false)
             }
@@ -493,9 +493,9 @@ class BrightFuturesTests: XCTestCase {
             return ()
         }
         
-        XCTAssert(!f.forced(0.2))
+        XCTAssert(f.forced(0.2) == nil)
         
-        XCTAssert(f.forced(0.3))
+        XCTAssert(f.forced(0.3) != nil)
     }
 
     func testComposedMapError() {


### PR DESCRIPTION
I made all the fixes necessary for the framework to work in Xcode Beta 5.

Due to some changes in the type inference, I had to add an explicit cast to the Int literal -- Swift was trying to convert the TaskValueWrapper<Int> to a MirrorDisposition rather than an Int.

Let me know if you figure out a cleaner fix.
