### PR TITLE
Fixed NSError domain and code

### DIFF
--- a/BrightFutures/Future.swift
+++ b/BrightFutures/Future.swift
@@ -50,7 +50,8 @@ public func future<T>(context c: ExecutionContext = Queue.global, task: () -> Re
     return promise.future
 }
 
-public let NoSuchElementError = "NoSuchElementError"
+public let NoSuchElementError = 0
+public let BrightFuturesErrorDomain = "nl.thomvis.BrightFutures"
 
 public class Future<T> {
     
@@ -439,7 +440,7 @@ public extension Future {
                 if p(val.value) {
                     promise.completeWith(self)
                 } else {
-                    promise.error(NSError(domain: NoSuchElementError, code: 0, userInfo: nil))
+                    promise.error(NSError(domain: BrightFuturesErrorDomain, code: NoSuchElementError, userInfo: nil))
                 }
                 break
             case .Failure(let err):

--- a/BrightFutures/FutureUtils.swift
+++ b/BrightFutures/FutureUtils.swift
@@ -54,7 +54,7 @@ public class FutureUtils {
                     return .Success(Box(elem))
                 }
             }
-            return .Failure(NSError(domain: NoSuchElementError, code: 0, userInfo: nil))
+            return .Failure(NSError(domain: BrightFuturesErrorDomain, code: NoSuchElementError, userInfo: nil))
         }
     }
     

--- a/BrightFuturesTests/BrightFuturesTests.swift
+++ b/BrightFuturesTests/BrightFuturesTests.swift
@@ -458,7 +458,7 @@ extension BrightFuturesTests {
         let e = self.expectation()
         future(3).filter { $0 > 5}.onComplete { result in
             if let err = result.error {
-				XCTAssert(err.code == NoSuchElementError, "filter should yield no result")
+                XCTAssert(err.code == NoSuchElementError, "filter should yield no result")
             }
             
             e.fulfill()

--- a/BrightFuturesTests/BrightFuturesTests.swift
+++ b/BrightFuturesTests/BrightFuturesTests.swift
@@ -458,7 +458,7 @@ extension BrightFuturesTests {
         let e = self.expectation()
         future(3).filter { $0 > 5}.onComplete { result in
             if let err = result.error {
-                XCTAssert(err.domain == NoSuchElementError, "filter should yield no result")
+				XCTAssert(err.code == NoSuchElementError, "filter should yield no result")
             }
             
             e.fulfill()
@@ -760,7 +760,7 @@ extension BrightFuturesTests {
         let e = self.expectation()
         
         f.onFailure { err in
-            XCTAssertEqual(err.domain, NoSuchElementError, "No matching elements")
+            XCTAssertEqual(err.code, NoSuchElementError, "No matching elements")
             e.fulfill()
         }
         


### PR DESCRIPTION
Changed NoSuchElementError to be an error code, and introduced BrightFuturesErrorDomain as the domain for NSErrors.