### PR TITLE
Back to swift 1.1

### DIFF
--- a/BrightFutures/Future.swift
+++ b/BrightFutures/Future.swift
@@ -302,8 +302,11 @@ public extension Future {
  * This extension contains all methods for registering callbacks
  */
 public extension Future {
-    
-    public func onComplete(context c: ExecutionContext = executionContextForCurrentContext(), callback: CompletionCallback) -> Future<T> {
+    public func onComplete(callback: CompletionCallback) -> Future<T> {
+        return onComplete(context: executionContextForCurrentContext(), callback: callback)
+    }
+
+    public func onComplete(context c: ExecutionContext, callback: CompletionCallback) -> Future<T> {
         let wrappedCallback : Future<T> -> () = { future in
             if let realRes = self.result {
                 c {
@@ -326,8 +329,12 @@ public extension Future {
         
         return self
     }
-    
-    public func onSuccess(context c: ExecutionContext = executionContextForCurrentContext(), callback: SuccessCallback) -> Future<T> {
+
+    public func onSuccess(callback: SuccessCallback) -> Future<T> {
+        return onSuccess(context: executionContextForCurrentContext(), callback: callback)
+    }
+
+    public func onSuccess(context c: ExecutionContext, callback: SuccessCallback) -> Future<T> {
         self.onComplete(context: c) { result in
             switch result {
             case .Success(let val):
@@ -340,6 +347,10 @@ public extension Future {
         return self
     }
     
+    public func onFailure(callback: FailureCallback) -> Future<T> {
+        return onFailure(callback: callback)
+    }
+
     public func onFailure(context c: ExecutionContext = executionContextForCurrentContext(), callback: FailureCallback) -> Future<T> {
         self.onComplete(context: c) { result in
             switch result {
@@ -358,7 +369,11 @@ public extension Future {
  */
 public extension Future {
 
-    public func flatMap<U>(context c: ExecutionContext = executionContextForCurrentContext(), f: T -> Future<U>) -> Future<U> {
+    public func flatMap<U>(f: T -> Future<U>) -> Future<U> {
+        return flatMap(context: executionContextForCurrentContext(), f: f)
+    }
+
+    public func flatMap<U>(context c: ExecutionContext, f: T -> Future<U>) -> Future<U> {
         let p: Promise<U> = Promise()
         self.onComplete(context: c) { res in
             switch (res) {
@@ -370,8 +385,12 @@ public extension Future {
         }
         return p.future
     }
-    
-    public func flatMap<U>(context c: ExecutionContext = executionContextForCurrentContext(), f: T -> Result<U>) -> Future<U> {
+
+    public func flatMap<U>(f: T -> Result<U>) -> Future<U> {
+        return flatMap(context: executionContextForCurrentContext(), f: f)
+    }
+
+    public func flatMap<U>(context c: ExecutionContext, f: T -> Result<U>) -> Future<U> {
         return self.flatMap(context: c) { value in
             Future.completed(f(value))
         }
@@ -398,7 +417,11 @@ public extension Future {
         return p.future
     }
 
-    public func andThen(context c: ExecutionContext = executionContextForCurrentContext(), callback: Result<T> -> ()) -> Future<T> {
+    public func andThen(callback: Result<T> -> ()) -> Future<T> {
+        return andThen(context: executionContextForCurrentContext(), callback: callback)
+    }
+
+    public func andThen(context c: ExecutionContext, callback: Result<T> -> ()) -> Future<T> {
         let p = Promise<T>()
         
         self.onComplete(context: c) { result in
@@ -408,14 +431,22 @@ public extension Future {
 
         return p.future
     }
-    
-    public func recover(context c: ExecutionContext = executionContextForCurrentContext(), task: (NSError) -> T) -> Future<T> {
+
+    public func recover(task: (NSError) -> T) -> Future<T> {
+        return recover(context:executionContextForCurrentContext(), task: task)
+    }
+
+    public func recover(context c: ExecutionContext, task: (NSError) -> T) -> Future<T> {
         return self.recoverWith(context: c) { error -> Future<T> in
             return Future.succeeded(task(error))
         }
     }
-    
-    public func recoverWith(context c: ExecutionContext = executionContextForCurrentContext(), task: (NSError) -> Future<T>) -> Future<T> {
+
+    public func recoverWith(task: (NSError) -> Future<T>) -> Future<T> {
+        return recoverWith(context: executionContextForCurrentContext(), task: task)
+    }
+
+    public func recoverWith(context c: ExecutionContext, task: (NSError) -> Future<T>) -> Future<T> {
         let p = Promise<T>()
         
         self.onComplete(context: c) { result -> () in
@@ -458,7 +489,11 @@ public extension Future {
         return FutureUtils.firstCompletedOf([self, token.future.asType()])
     }
     
-    public func onComplete(context c: ExecutionContext = executionContextForCurrentContext(), token: InvalidationTokenType, callback: Result<T> -> ()) -> Future<T> {
+    public func onComplete(#token: InvalidationTokenType, callback: Result<T> -> ()) -> Future<T> {
+        return onComplete(context: executionContextForCurrentContext(), token: token, callback: callback)
+    }
+
+    public func onComplete(context c: ExecutionContext, token: InvalidationTokenType, callback: Result<T> -> ()) -> Future<T> {
         firstCompletedOfSelfAndToken(token).onComplete(context: c) { res in
             token.context {
                 if !token.isInvalid {
@@ -468,8 +503,12 @@ public extension Future {
         }
         return self;
     }
-    
-    public func onSuccess(context c: ExecutionContext = executionContextForCurrentContext(), token: InvalidationTokenType, callback: SuccessCallback) -> Future<T> {
+
+    public func onSuccess(#token: InvalidationTokenType, callback: SuccessCallback) -> Future<T> {
+        return onSuccess(context: executionContextForCurrentContext(), token: token, callback: callback)
+    }
+
+    public func onSuccess(context c: ExecutionContext, token: InvalidationTokenType, callback: SuccessCallback) -> Future<T> {
         firstCompletedOfSelfAndToken(token).onSuccess(context: c) { value in
             token.context {
                 if !token.isInvalid {
@@ -480,8 +519,12 @@ public extension Future {
         
         return self
     }
-    
-    public func onFailure(context c: ExecutionContext = executionContextForCurrentContext(), token: InvalidationTokenType, callback: FailureCallback) -> Future<T> {
+
+    public func onFailure(#token: InvalidationTokenType, callback: FailureCallback) -> Future<T> {
+        return onFailure(context: executionContextForCurrentContext(), token: token, callback: callback)
+    }
+
+    public func onFailure(context c: ExecutionContext, token: InvalidationTokenType, callback: FailureCallback) -> Future<T> {
         firstCompletedOfSelfAndToken(token).onFailure(context: c) { error in
             token.context {
                 println("Failure")

--- a/BrightFuturesTests/BrightFuturesTests.swift
+++ b/BrightFuturesTests/BrightFuturesTests.swift
@@ -933,5 +933,5 @@ func fibonacciFuture(n: Int) -> Future<Int> {
 }
 
 func getMutablePointer (object: AnyObject) -> UnsafeMutablePointer<Void> {
-    return UnsafeMutablePointer<Void>(bitPattern: Word(ObjectIdentifier(object).uintValue))
+    return UnsafeMutablePointer<Void>(bitPattern: Word(ObjectIdentifier(object).uintValue()))
 }

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ let f = future { () -> Result<NSDate> in
   if let someNow = now {
     return .Success(Box(someNow))
   }
-  
+
   return .Failure(NSError(domain: "TimeServiceErrorDomain", code: 404, userInfo: nil))
 }
 
@@ -96,9 +96,9 @@ func asyncCalculation() -> Future<String> {
   let promise = Promise<String>()
 
   Queue.global.async {
-  
+
     // do a complicated task
-    
+
     promise.success("forty-two")
   }
 
@@ -186,11 +186,11 @@ If a `Future` fails, use `recover` to offer a default or alternative value and c
 ```swift
 let f = future { () -> Result<Int> in
     // request something from the web
-    
+
     if (request.error) { // it could fail
         return .Failure(request.error)
     }
-    
+
     return .Success(Box(10))
 }.recover { _ in // provide an offline default
     return 5
@@ -275,7 +275,8 @@ An invalidation token can be used to invalidate a callback, preventing it from b
 class MyCell : UICollectionViewCell {
   var token = InvalidationToken()
 
-  public override func prepareForReuse() {
+public override func prepareForReuse() {
+    super.prepareForReuse()
     token.invalidate()
     token = InvalidationToken()
   }

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ An invalidation token can be used to invalidate a callback, preventing it from b
 class MyCell : UICollectionViewCell {
   var token = InvalidationToken()
 
-public override func prepareForReuse() {
+  public override func prepareForReuse() {
     super.prepareForReuse()
     token.invalidate()
     token = InvalidationToken()

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ func asyncCalculation() -> Future<String> {
   let promise = Promise<String>()
 
   Queue.global.async {
-
+  
     // do a complicated task
     
     promise.success("forty-two")

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ let f = future { () -> Result<NSDate> in
   if let someNow = now {
     return .Success(Box(someNow))
   }
-
+  
   return .Failure(NSError(domain: "TimeServiceErrorDomain", code: 404, userInfo: nil))
 }
 
@@ -98,7 +98,7 @@ func asyncCalculation() -> Future<String> {
   Queue.global.async {
 
     // do a complicated task
-
+    
     promise.success("forty-two")
   }
 
@@ -186,11 +186,11 @@ If a `Future` fails, use `recover` to offer a default or alternative value and c
 ```swift
 let f = future { () -> Result<Int> in
     // request something from the web
-
+    
     if (request.error) { // it could fail
         return .Failure(request.error)
     }
-
+    
     return .Success(Box(10))
 }.recover { _ in // provide an offline default
     return 5


### PR DESCRIPTION
This is a minimal set of changes to get current master to compile on official XCode 6.1.1 and Swift 1.1. 

Fixes #31 and as described in the issue report I suggest that Swift 1.2 support is moved to a separate branch and master branch works against official XCode version.

Not tested extensively, but logic tests pass on a simulator and a real project that was previously using 1.0.0.beta2 compiles and works against this branch both in a simulator and a device. (compiled with XCode Version 6.1.1 (6A2008a) and Swift 1.1.)

