### PR TITLE
Access modifier changes.

### DIFF
--- a/BrightFutures/Future.swift
+++ b/BrightFutures/Future.swift
@@ -237,7 +237,7 @@ public extension Future {
     public class func completeAfter(delay: NSTimeInterval, withValue value: T) -> Future<T> {
         let res = Future<T>()
         
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(delay * NSTimeInterval(NSEC_PER_SEC))), Queue.global.queue) {
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(delay * NSTimeInterval(NSEC_PER_SEC))), Queue.global.underlyingQueue) {
             res.success(value)
         }
         

--- a/BrightFutures/Queue.swift
+++ b/BrightFutures/Queue.swift
@@ -53,7 +53,7 @@ public struct Queue {
      */
     public static let global = Queue(queue: dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0))
     
-    var queue: dispatch_queue_t
+    private(set) public var underlyingQueue: dispatch_queue_t
     
     public var context: ExecutionContext {
         return { task in
@@ -66,7 +66,7 @@ public struct Queue {
      * If `param` is omitted, a serial queue with identifier "queue" is used.
      */
     public init(queue: dispatch_queue_t = dispatch_queue_create("queue", DISPATCH_QUEUE_SERIAL)) {
-        self.queue = queue
+        self.underlyingQueue = queue
     }
     
     /**
@@ -74,7 +74,7 @@ public struct Queue {
      * Identical to dispatch_sync(self.queue, block)
      */
     public func sync(block: () -> ()) {
-        dispatch_sync(queue, block)
+        dispatch_sync(underlyingQueue, block)
     }
     
     /**
@@ -97,7 +97,7 @@ public struct Queue {
      * Identical to dispatch_async(self.queue, block)
      */
     public func async(block: () -> ()) {
-        dispatch_async(queue, block)
+        dispatch_async(underlyingQueue, block)
     }
     
     public func async<T>(block: () -> T) -> Future<T> {
@@ -115,7 +115,7 @@ public struct Queue {
      * Identical to dispatch_after(dispatch_time, self.queue, block)
      */
     public func after(delay: TimeInterval, block: () -> ()) {
-        dispatch_after(delay.dispatchTime, queue, block)
+        dispatch_after(delay.dispatchTime, underlyingQueue, block)
     }
     
     public func after<T>(delay: TimeInterval, block: () -> T) -> Future<T> {

--- a/BrightFutures/Semaphore.swift
+++ b/BrightFutures/Semaphore.swift
@@ -26,7 +26,7 @@ public enum TimeInterval {
     case Forever
     case In(NSTimeInterval)
     
-    var dispatchTime: dispatch_time_t {
+    public var dispatchTime: dispatch_time_t {
         get {
             switch self {
             case .Forever:
@@ -41,31 +41,31 @@ public enum TimeInterval {
 /**
  * A tiny wrapper around dispatch_semaphore
  */
-class Semaphore {
+public class Semaphore {
     
-    private var semaphore: dispatch_semaphore_t
+    private(set) public var underlyingSemaphore: dispatch_semaphore_t
     
-    init(value: Int) {
-        self.semaphore = dispatch_semaphore_create(value)
+    public init(value: Int) {
+        self.underlyingSemaphore = dispatch_semaphore_create(value)
     }
     
-    convenience init() {
+    public convenience init() {
         self.init(value: 1)
     }
     
-    func wait() {
+    public func wait() {
         self.wait(.Forever)
     }
     
-    func wait(timeout: TimeInterval) {
-        dispatch_semaphore_wait(self.semaphore, timeout.dispatchTime)
+    public func wait(timeout: TimeInterval) {
+        dispatch_semaphore_wait(self.underlyingSemaphore, timeout.dispatchTime)
     }
     
-    func signal() {
-        dispatch_semaphore_signal(self.semaphore)
+    public func signal() {
+        dispatch_semaphore_signal(self.underlyingSemaphore)
     }
 
-    func execute(task: () -> ()) {
+    public func execute(task: () -> ()) {
         self.wait()
         task()
         self.signal()


### PR DESCRIPTION
Hi there, I love the BrightFutures library and I love some of the dispatch wrapper classes that are defined in it and i'd love to use them in my own code.

So I've:
- Made the `Semaphore` wrapper class public and renamed it's private `semaphore` property `underlyingSemaphore` and made it publicly readable/readwrite internally.
- Made the `dispatchTime` computed property of the already public `TimeInterval` enum public.
- Made the private `queue` property of the `Queue` struct publicly readable/readwrite internally and renamed it `underlyingQueue`

My reasons for naming the private semaphore/queue as underlyingSemaphore/queue was because when defining one of them someone will generally write: 

```swift
let queue = Queue()
``` 
then when using the underlying queue have to write 
```swift
someFuncThatNeedsADispatchQueue(queue.queue)
``` 

which seems weird.

Also `NSOperationQueue` has a similar [underlyingQueue](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/NSOperationQueue_class/index.html#//apple_ref/occ/instp/NSOperationQueue/underlyingQueue) property.