### PR TITLE
Fixing Queue comments

### DIFF
--- a/BrightFutures/Queue.swift
+++ b/BrightFutures/Queue.swift
@@ -71,7 +71,7 @@ public struct Queue {
     
     /**
      * Synchronously executes the given block on the queue. 
-     * Identical to dispatch_sync(self.queue, block)
+     * Identical to dispatch_sync(self.underlyingQueue, block)
      */
     public func sync(block: () -> ()) {
         dispatch_sync(underlyingQueue, block)
@@ -94,7 +94,7 @@ public struct Queue {
     
     /**
      * Asynchronously executes the given block on the queue.
-     * Identical to dispatch_async(self.queue, block)
+     * Identical to dispatch_async(self.underlyingQueue, block)
      */
     public func async(block: () -> ()) {
         dispatch_async(underlyingQueue, block)
@@ -112,7 +112,7 @@ public struct Queue {
     
     /**
      * Asynchronously executes the given block on the queue after a delay
-     * Identical to dispatch_after(dispatch_time, self.queue, block)
+     * Identical to dispatch_after(dispatch_time, self.underlyingQueue, block)
      */
     public func after(delay: TimeInterval, block: () -> ()) {
         dispatch_after(delay.dispatchTime, underlyingQueue, block)


### PR DESCRIPTION
Hi there, I noticed today that during the rename of the `queue` property of the Queue struct `underlyingQueue` in #38, I did not fix the comments referring to `self.queue`, i've done that in this PR.