### PR TITLE
Fix compiler crash in Release mode

### DIFF
--- a/BrightFutures/Errors.swift
+++ b/BrightFutures/Errors.swift
@@ -40,7 +40,7 @@ extension NoError: ErrorType {
     /// From `ErrorType`: an NSError describing this error.
     /// Since `NoError` cannot be constructed, this property can also never be accessed.
     public var nsError: NSError {
-        fatalError("Impossible to construct NoError")
+        preconditionFailure("Impossible to construct NoError")
     }
 }
 


### PR DESCRIPTION
`fatalError ` crash compiler in Release mode (for example with building branch with Carthage)
but `preconditionFailure ` so let's use it instead ?