### PR TITLE
Fix compiler crash in Release mode take 2

### DIFF
--- a/BrightFutures/Errors.swift
+++ b/BrightFutures/Errors.swift
@@ -32,7 +32,11 @@ public protocol ErrorType {
 
 /// Can be used as the value type of a `Future` or `Result` to indicate it can never fail.
 /// This is guaranteed by the type system, because `NoError` has no possible values and thus cannot be created.
-public enum NoError {}
+public class NoError {
+    private init() {
+        fatalError("impossible to instantiate NoError")
+    }
+}
 
 /// Extends `NSError` to conform to `ErrorType`
 extension NoError: ErrorType {


### PR DESCRIPTION
if convert NoError to a class the compiler stop crashing in Release. (if it's an enum / struct it crashes)