### PR TITLE
Swift2 2.0 development

### DIFF
--- a/BrightFutures.xcodeproj/project.pbxproj
+++ b/BrightFutures.xcodeproj/project.pbxproj
@@ -9,8 +9,6 @@
 /* Begin PBXBuildFile section */
 		E9039ADD1A45DF8D000DD6F1 /* ResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9039ADC1A45DF8D000DD6F1 /* ResultTests.swift */; };
 		E907D1DE1A6AE4A000AB8075 /* Semaphore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E907D1DD1A6AE4A000AB8075 /* Semaphore.swift */; };
-		E90E9D581B1B8A3600A8F9F3 /* Box.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E90E9D571B1B8A3600A8F9F3 /* Box.framework */; };
-		E90E9D5E1B1B8A7200A8F9F3 /* Box.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E90E9D591B1B8A4100A8F9F3 /* Box.framework */; };
 		E90E9D601B1B8A9B00A8F9F3 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E90E9D5F1B1B8A9B00A8F9F3 /* Result.framework */; };
 		E90E9D621B1B8AA500A8F9F3 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E90E9D611B1B8AA500A8F9F3 /* Result.framework */; };
 		E9319EA41A397D2C00A0604A /* QueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9319EA31A397D2C00A0604A /* QueueTests.swift */; };
@@ -88,8 +86,6 @@
 /* Begin PBXFileReference section */
 		E9039ADC1A45DF8D000DD6F1 /* ResultTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultTests.swift; sourceTree = "<group>"; };
 		E907D1DD1A6AE4A000AB8075 /* Semaphore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Semaphore.swift; sourceTree = "<group>"; };
-		E90E9D571B1B8A3600A8F9F3 /* Box.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Box.framework; path = Carthage/Checkouts/Result/Carthage/Checkouts/Box/build/Debug/Box.framework; sourceTree = "<group>"; };
-		E90E9D591B1B8A4100A8F9F3 /* Box.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Box.framework; path = "../../../Library/Developer/Xcode/DerivedData/BrightFutures-brlkgomqpbjfnpbdastdlmrhcaoc/Build/Products/Debug/Box.framework"; sourceTree = "<group>"; };
 		E90E9D5F1B1B8A9B00A8F9F3 /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Result.framework; path = "Carthage/Checkouts/Result/build/Debug-iphoneos/Result.framework"; sourceTree = "<group>"; };
 		E90E9D611B1B8AA500A8F9F3 /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Result.framework; path = Carthage/Checkouts/Result/build/Debug/Result.framework; sourceTree = "<group>"; };
 		E9319EA31A397D2C00A0604A /* QueueTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueueTests.swift; sourceTree = "<group>"; };
@@ -118,7 +114,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				E90E9D621B1B8AA500A8F9F3 /* Result.framework in Frameworks */,
-				E90E9D581B1B8A3600A8F9F3 /* Box.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -135,7 +130,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				E90E9D601B1B8A9B00A8F9F3 /* Result.framework in Frameworks */,
-				E90E9D5E1B1B8A7200A8F9F3 /* Box.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -163,7 +157,6 @@
 			isa = PBXGroup;
 			children = (
 				E90E9D5F1B1B8A9B00A8F9F3 /* Result.framework */,
-				E90E9D591B1B8A4100A8F9F3 /* Box.framework */,
 			);
 			name = iOS;
 			sourceTree = "<group>";
@@ -172,7 +165,6 @@
 			isa = PBXGroup;
 			children = (
 				E90E9D611B1B8AA500A8F9F3 /* Result.framework */,
-				E90E9D571B1B8A3600A8F9F3 /* Box.framework */,
 			);
 			name = Mac;
 			sourceTree = "<group>";
@@ -342,7 +334,8 @@
 		E9DF080C194470060083F7F2 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0600;
+				LastSwiftUpdateCheck = 0700;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Thomas Visser";
 				TargetAttributes = {
 					E9D45AFF1AF00659000F6CA7 = {
@@ -491,6 +484,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "nl.thomvis.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = BrightFutures;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -515,6 +509,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "nl.thomvis.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = BrightFutures;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -540,6 +535,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "nl.thomvis.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 			};
@@ -561,6 +557,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "nl.thomvis.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 			};
@@ -586,6 +583,7 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -662,6 +660,7 @@
 				INFOPLIST_FILE = BrightFutures/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "nl.thomvis.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = BrightFutures;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -681,6 +680,7 @@
 				INFOPLIST_FILE = BrightFutures/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "nl.thomvis.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = BrightFutures;
 				SKIP_INSTALL = YES;
 			};
@@ -691,7 +691,6 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
@@ -702,6 +701,7 @@
 				INFOPLIST_FILE = BrightFuturesTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				METAL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "nl.thomvis.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -711,13 +711,13 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = BrightFuturesTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				METAL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "nl.thomvis.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/BrightFutures.xcodeproj/xcshareddata/xcschemes/BrightFutures-Mac.xcscheme
+++ b/BrightFutures.xcodeproj/xcshareddata/xcschemes/BrightFutures-Mac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0630"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -62,6 +62,8 @@
             ReferencedContainer = "container:BrightFutures.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
@@ -71,6 +73,7 @@
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/BrightFutures.xcodeproj/xcshareddata/xcschemes/BrightFutures-iOS.xcscheme
+++ b/BrightFutures.xcodeproj/xcshareddata/xcschemes/BrightFutures-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -62,6 +62,8 @@
             ReferencedContainer = "container:BrightFutures.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
@@ -71,6 +73,7 @@
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/BrightFutures.xcworkspace/contents.xcworkspacedata
+++ b/BrightFutures.xcworkspace/contents.xcworkspacedata
@@ -5,9 +5,6 @@
       location = "container:BrightFutures.xcodeproj">
    </FileRef>
    <FileRef
-      location = "group:Carthage/Checkouts/Result/Carthage/Checkouts/Box/Box.xcodeproj">
-   </FileRef>
-   <FileRef
       location = "group:Carthage/Checkouts/Result/Result.xcodeproj">
    </FileRef>
 </Workspace>

--- a/BrightFutures/Errors.swift
+++ b/BrightFutures/Errors.swift
@@ -22,39 +22,12 @@
 
 import Foundation
 
-/// To be able to use a type as an error type with BrightFutures, it needs to conform
-/// to this protocol.
-public extension ErrorType {
-    /// An NSError describing this error
-    var nsError: NSError { return NSError(domain: "fake", code: 0, userInfo: nil) }
-}
-
 /// Can be used as the value type of a `Future` or `Result` to indicate it can never fail.
 /// This is guaranteed by the type system, because `NoError` has no possible values and thus cannot be created.
 public enum NoError {}
 
-/// Extends `NSError` to conform to `ErrorType`
-extension NoError: ErrorType {
-    
-    /// From `ErrorType`: an NSError describing this error.
-    /// Since `NoError` cannot be constructed, this property can also never be accessed.
-    public var nsError: NSError {
-        fatalError("Impossible to construct NoError")
-    }
-}
-
-/// An extension of `NSError` to make it conform to `ErrorType`
-extension NSError {
-    
-    /// From `ErrorType`: An NSError describing this error.
-    /// Will return `self`.
-    public var nsError: NSError {
-        return self
-    }
-}
-
-/// The name of the domain that will be used when returning `NSError` representations of `BrightFuturesError` instances
-public let BrightFuturesErrorDomain = "nl.thomvis.BrightFutures"
+/// Extends `NoError` to conform to `ErrorType`
+extension NoError: ErrorType {}
 
 /// An enum representing every possible error for errors returned by BrightFutures
 /// A `BrightFuturesError` can also wrap an external error (e.g. coming from a user defined future)
@@ -68,17 +41,17 @@ public enum BrightFuturesError<E: ErrorType>: ErrorType {
     public init(external: E) {
         self = .External(external)
     }
-    
-    /// From `ErrorType`: An NSError describing this error.
-    public var nsError: NSError {
-        switch self {
-        case .NoSuchElement:
-            return NSError(domain: BrightFuturesErrorDomain, code: 0, userInfo: nil)
-        case .InvalidationTokenInvalidated:
-            return NSError(domain: BrightFuturesErrorDomain, code: 1, userInfo: nil)
-        case .External(let error):
-            return error.nsError
-        }
-    }
+}
 
+/// Extends `BrightFuturesError` to conform to `Equatable`
+extension BrightFuturesError: Equatable {}
+
+/// Returns `true` if `left` and `right` are both of the same case ignoring .External associated value
+public func ==<E: ErrorType>(lhs: BrightFuturesError<E>, rhs: BrightFuturesError<E>) -> Bool {
+    switch (lhs, rhs) {
+    case (.NoSuchElement, .NoSuchElement): return true
+    case (.InvalidationTokenInvalidated, .InvalidationTokenInvalidated): return true
+    case (.External(_), .External(_)): return true
+    default: return false
+    }
 }

--- a/BrightFutures/Errors.swift
+++ b/BrightFutures/Errors.swift
@@ -21,13 +21,12 @@
 // SOFTWARE.
 
 import Foundation
-import Box
 
 /// To be able to use a type as an error type with BrightFutures, it needs to conform
 /// to this protocol.
-public protocol ErrorType {
+public extension ErrorType {
     /// An NSError describing this error
-    var nsError: NSError { get }
+    var nsError: NSError { return NSError(domain: "fake", code: 0, userInfo: nil) }
 }
 
 /// Can be used as the value type of a `Future` or `Result` to indicate it can never fail.
@@ -45,7 +44,7 @@ extension NoError: ErrorType {
 }
 
 /// An extension of `NSError` to make it conform to `ErrorType`
-extension NSError: ErrorType {
+extension NSError {
     
     /// From `ErrorType`: An NSError describing this error.
     /// Will return `self`.
@@ -64,10 +63,10 @@ public enum BrightFuturesError<E: ErrorType>: ErrorType {
     
     case NoSuchElement
     case InvalidationTokenInvalidated
-    case External(Box<E>)
+    case External(E)
 
     public init(external: E) {
-        self = .External(Box(external))
+        self = .External(external)
     }
     
     /// From `ErrorType`: An NSError describing this error.
@@ -77,8 +76,8 @@ public enum BrightFuturesError<E: ErrorType>: ErrorType {
             return NSError(domain: BrightFuturesErrorDomain, code: 0, userInfo: nil)
         case .InvalidationTokenInvalidated:
             return NSError(domain: BrightFuturesErrorDomain, code: 1, userInfo: nil)
-        case .External(let boxedError):
-            return boxedError.value.nsError
+        case .External(let error):
+            return error.nsError
         }
     }
 

--- a/BrightFutures/Future.swift
+++ b/BrightFutures/Future.swift
@@ -25,29 +25,29 @@ import Result
 
 /// Executes the given task on `Queue.global` and wraps the result of the task in a Future
 public func future<T>(@autoclosure(escaping) task: () -> T) -> Future<T, NoError> {
-    return future(context: Queue.global.context, task)
+    return future(context: Queue.global.context, task: task)
 }
 
 /// Executes the given task on `Queue.global` and wraps the result of the task in a Future
 public func future<T>(task: () -> T) -> Future<T, NoError> {
-    return future(context: Queue.global.context, task)
+    return future(context: Queue.global.context, task: task)
 }
 
 /// Executes the given task on the given context and wraps the result of the task in a Future
 public func future<T>(context c: ExecutionContext, task: () -> T) -> Future<T, NoError> {
-    return future(context: c, { () -> Result<T, NoError> in
+    return future(context: c) { () -> Result<T, NoError> in
         return Result(value: task())
-    })
+    }
 }
 
 /// Executes the given task on `Queue.global` and wraps the result of the task in a Future
 public func future<T, E>(@autoclosure(escaping) task: () -> Result<T, E>) -> Future<T, E> {
-    return future(context: Queue.global.context, task)
+    return future(context: Queue.global.context, task: task)
 }
 
 /// Executes the given task on `Queue.global` and wraps the result of the task in a Future
 public func future<T, E>(task: () -> Result<T, E>) -> Future<T, E> {
-    return future(context: Queue.global.context, task)
+    return future(context: Queue.global.context, task: task)
 }
 
 /// Executes the given task on the given context and wraps the result of the task in a Future
@@ -137,9 +137,9 @@ internal extension Future {
     func tryComplete(result: Result<T,E>) -> Bool {
         switch result {
         case .Success(let val):
-            return self.trySuccess(val.value)
+            return self.trySuccess(val)
         case .Failure(let err):
-            return self.tryFailure(err.value)
+            return self.tryFailure(err)
         }
     }
 
@@ -606,7 +606,7 @@ public func promoteError<T, E>(future: Future<T, BrightFuturesError<NoError>>) -
             return BrightFuturesError<E>.NoSuchElement
         case .InvalidationTokenInvalidated:
             return BrightFuturesError<E>.InvalidationTokenInvalidated
-        case .External(let err):
+        case .External(_):
             fatalError("Encountered BrightFuturesError.External with NoError, which should be impossible")
         }
     }

--- a/BrightFutures/Info.plist
+++ b/BrightFutures/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>nl.thomvis.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/BrightFutures/InvalidationToken.swift
+++ b/BrightFutures/InvalidationToken.swift
@@ -8,9 +8,6 @@
 
 import Foundation
 
-/// The error code that a token's future will fail with when the token is invalidated
-public let InvalidationTokenInvalid = 1
-
 /// The type that all invalidation tokens conform to
 public protocol InvalidationTokenType {
     

--- a/BrightFuturesTests/BrightFuturesTests.swift
+++ b/BrightFuturesTests/BrightFuturesTests.swift
@@ -137,23 +137,18 @@ extension BrightFuturesTests {
     func testForceTypeFailure() {
         class TestError: ErrorType {
             var _domain: String { return "TestError" }
-            var _code: Int { return 2 }
-            
-            var nsError: NSError {
-                return NSError(domain: "", code: 1, userInfo: nil)
-            }
+            var _code: Int { return 1 }
         }
         
         class SubError: TestError {
-            override var nsError: NSError {
-                return NSError(domain: "", code: 2, userInfo: nil)
-            }
+            override var _domain: String { return "" }
+            override var _code: Int { return 2 }
         }
         
         let f: Future<NoValue, TestError> = Future.failed(SubError())
         let f1: Future<NoValue, SubError> = f.forceType()
         
-        XCTAssertEqual(f1.result!.error!.nsError.code, 2, "Should be a SubError")
+        XCTAssertEqual(f1.result!.error!._code, 2, "Should be a SubError")
     }
     
     func testControlFlowSyntax() {
@@ -225,7 +220,7 @@ extension BrightFuturesTests {
         let e1 = self.expectation()
 
         f1.onFailure { error in
-            XCTAssertEqual(error.nsError, BrightFuturesError<NoError>.NoSuchElement.nsError)
+            XCTAssertEqual(error, BrightFuturesError<NoError>.NoSuchElement)
             e1.fulfill()
         }
         
@@ -540,7 +535,7 @@ extension BrightFuturesTests {
         let e = self.expectation()
         Future<Int, NoError>.succeeded(3).filter { $0 > 5}.onComplete { result in
             if let err = result.error {
-                XCTAssert(err.nsError.code == 0, "filter should yield no result")
+                XCTAssert(err == BrightFuturesError<NoError>.NoSuchElement, "filter should yield no result")
             }
             
             e.fulfill()
@@ -846,7 +841,7 @@ extension BrightFuturesTests {
         let e = self.expectation()
         
         f.onFailure { err in
-            XCTAssertEqual(err.nsError.code, 0, "No matching elements")
+            XCTAssertEqual(err, BrightFuturesError<NoError>.NoSuchElement, "No matching elements")
             e.fulfill()
         }
         

--- a/BrightFuturesTests/BrightFuturesTests.swift
+++ b/BrightFuturesTests/BrightFuturesTests.swift
@@ -77,10 +77,10 @@ extension BrightFuturesTests {
         
         f.onComplete { result in
             switch result {
-            case .Success(let val):
+            case .Success(_):
                 XCTAssert(false)
-            case .Failure(let boxedErr):
-                XCTAssertEqual(boxedErr.value, error)
+            case .Failure(let err):
+                XCTAssertEqual(err, error)
             }
             completeExpectation.fulfill()
         }
@@ -136,6 +136,9 @@ extension BrightFuturesTests {
     
     func testForceTypeFailure() {
         class TestError: ErrorType {
+            var _domain: String { return "TestError" }
+            var _code: Int { return 2 }
+            
             var nsError: NSError {
                 return NSError(domain: "", code: 1, userInfo: nil)
             }
@@ -241,7 +244,7 @@ extension BrightFuturesTests {
         p.future.onComplete { result in
             switch result {
             case .Success(let val):
-                XCTAssert(Int(55) == val.value)
+                XCTAssert(Int(55) == val)
             case .Failure(_):
                 XCTAssert(false)
             }
@@ -645,7 +648,7 @@ extension BrightFuturesTests {
             }
         }
         
-        let f = traverse([2,4,6,8,9,10], context: Queue.global.context, evenFuture)
+        let f = traverse([2,4,6,8,9,10], context: Queue.global.context, f: evenFuture)
             
             
         f.onFailure { err in
@@ -669,7 +672,7 @@ extension BrightFuturesTests {
             }
         }
         
-        traverse([20,22,23,26,27,30], evenFuture).onFailure { err in
+        traverse([20,22,23,26,27,30], f: evenFuture).onFailure { err in
             XCTAssertEqual(err.code, 23)
             e.fulfill()
         }
@@ -698,7 +701,7 @@ extension BrightFuturesTests {
         
         let e = self.expectation()
         
-        fold(fibonacciList, 0, { $0 + $1 }).onSuccess { val in
+        fold(fibonacciList, zero: 0, f: { $0 + $1 }).onSuccess { val in
             XCTAssertEqual(val, 143)
             e.fulfill()
         }
@@ -720,7 +723,7 @@ extension BrightFuturesTests {
         
         let e = self.expectation()
         
-        fold(fibonacciList, 0, { $0 + $1 }).onFailure { err in
+        fold(fibonacciList, zero: 0, f: { $0 + $1 }).onFailure { err in
             XCTAssertEqual(err, error)
             e.fulfill()
         }
@@ -731,7 +734,7 @@ extension BrightFuturesTests {
     func testUtilsFoldWithExecutionContext() {
         let e = self.expectation()
         
-        fold([Future<Int, NoError>.succeeded(1)], context: Queue.main.context, 10) { remainder, elem -> Int in
+        fold([Future<Int, NoError>.succeeded(1)], context: Queue.main.context, zero: 10) { remainder, elem -> Int in
             XCTAssert(NSThread.isMainThread())
             return remainder + elem
         }.onSuccess { val in
@@ -747,7 +750,7 @@ extension BrightFuturesTests {
         
         let e = self.expectation()
         
-        fold([Future<String, NoError>](), z, { $0 + $1 }).onSuccess { val in
+        fold([Future<String, NoError>](), zero: z, f: { $0 + $1 }).onSuccess { val in
             XCTAssertEqual(val, z)
             e.fulfill()
         }
@@ -781,7 +784,7 @@ extension BrightFuturesTests {
         let e = self.expectation()
         
         sequence(futures).onSuccess { fibs in
-            for (index, num) in enumerate(fibs) {
+            for (index, num) in fibs.enumerate() {
                 XCTAssertEqual(fibonacci(index+1), num)
             }
             

--- a/BrightFuturesTests/ErrorsTests.swift
+++ b/BrightFuturesTests/ErrorsTests.swift
@@ -25,30 +25,9 @@ import BrightFutures
 
 enum TestError: ErrorType {
     case JustAnError
-    
-    var nsError: NSError {
-        return NSError(domain: "TestError", code: 1, userInfo: nil)
-    }
 }
 
 class ErrorsTests: XCTestCase {
-    
-    func testNSError() {
-        let error = NSError(domain: "TestDomain", code: 2, userInfo: nil)
-        XCTAssert(error === error.nsError, "nsError should return itself")
-    }
-    
-    func testNoSuchElementError() {
-        let error = BrightFuturesError<NoError>.NoSuchElement
-        XCTAssertEqual(error.nsError.domain, BrightFuturesErrorDomain)
-        XCTAssertEqual(error.nsError.code, 0)
-    }
-    
-    func testInvalidationError() {
-        let error = BrightFuturesError<NoError>.InvalidationTokenInvalidated
-        XCTAssertEqual(error.nsError.domain, BrightFuturesErrorDomain)
-        XCTAssertEqual(error.nsError.code, 1)
-    }
     
     func testExternalError() {
         let externalError = TestError.JustAnError
@@ -60,8 +39,6 @@ class ErrorsTests: XCTestCase {
         default:
             XCTFail("Should match with the external case")
         }
-        
-        XCTAssertEqual(externalError.nsError, error.nsError)
     }
     
 }

--- a/BrightFuturesTests/ErrorsTests.swift
+++ b/BrightFuturesTests/ErrorsTests.swift
@@ -34,7 +34,7 @@ enum TestError: ErrorType {
 class ErrorsTests: XCTestCase {
     
     func testNSError() {
-        let error = NSError()
+        let error = NSError(domain: "TestDomain", code: 2, userInfo: nil)
         XCTAssert(error === error.nsError, "nsError should return itself")
     }
     
@@ -55,8 +55,8 @@ class ErrorsTests: XCTestCase {
         let error = BrightFuturesError(external: externalError)
         
         switch error {
-        case .External(let boxedError):
-            XCTAssertEqual(boxedError.value, TestError.JustAnError, "Should be same error")
+        case .External(let err):
+            XCTAssertEqual(err, TestError.JustAnError, "Should be same error")
         default:
             XCTFail("Should match with the external case")
         }

--- a/BrightFuturesTests/Info.plist
+++ b/BrightFuturesTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>nl.thomvis.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/BrightFuturesTests/InvalidationTokenTests.swift
+++ b/BrightFuturesTests/InvalidationTokenTests.swift
@@ -28,9 +28,8 @@ class InvalidationTokenTests: XCTestCase {
         XCTAssert(!token.future.isCompleted, "token should have a future and not be complete")
         token.invalidate()
         XCTAssert(token.future.error != nil, "future should have an error")
-        if let error = token.future.error?.nsError {
-            XCTAssertEqual(error.domain, BrightFuturesErrorDomain)
-            XCTAssertEqual(error.code, InvalidationTokenInvalid)
+        if let error = token.future.error {
+            XCTAssertEqual(error, BrightFuturesError.InvalidationTokenInvalidated)
         }
     }
     

--- a/BrightFuturesTests/ResultTests.swift
+++ b/BrightFuturesTests/ResultTests.swift
@@ -60,7 +60,7 @@ class ResultTests: XCTestCase {
     }
     
     func testFailure() {
-        let error = NSError()
+        let error = NSError(domain: "TestDomain", code: 2, userInfo: nil)
         let result = Result<Int, NSError>(error: error)
         XCTAssert(result.isFailure)
         XCTAssertFalse(result.isSuccess)
@@ -188,7 +188,7 @@ enum MathError: ErrorType {
     }
 }
 
-func divide(a: Int, b: Int) -> Result<Int, MathError> {
+func divide(a: Int, _ b: Int) -> Result<Int, MathError> {
     if (b == 0) {
         return Result(error: .DivisionByZero)
     }

--- a/BrightFuturesTests/ResultTests.swift
+++ b/BrightFuturesTests/ResultTests.swift
@@ -103,7 +103,7 @@ class ResultTests: XCTestCase {
         }
         
         XCTAssert(r.isFailure)
-        XCTAssertEqual(r.error!.nsError.code, 123)
+        XCTAssertEqual(r.error!, MathError.DivisionByZero)
     }
 
     func testFlatMapFutureSuccess() {
@@ -134,7 +134,7 @@ class ResultTests: XCTestCase {
         let e = self.expectation()
         
         f.onFailure { err in
-            XCTAssertEqual(err.nsError.code, 123)
+            XCTAssertEqual(err, MathError.DivisionByZero)
             e.fulfill()
         }
         
@@ -159,7 +159,7 @@ class ResultTests: XCTestCase {
         
         let r = sequence(results)
         XCTAssert(r.isFailure)
-        XCTAssertEqual(r.error!.nsError.code, 123)
+        XCTAssertEqual(r.error!, MathError.DivisionByZero)
     }
 
     func testRecoverNeeded() {
@@ -179,13 +179,6 @@ class ResultTests: XCTestCase {
 
 enum MathError: ErrorType {
     case DivisionByZero
-    
-    var nsError: NSError {
-        switch self {
-        case .DivisionByZero:
-            return NSError(domain: "nl.thomvis.brightfuturestests", code: 123, userInfo: nil);
-        }
-    }
 }
 
 func divide(a: Int, _ b: Int) -> Result<Int, MathError> {

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "antitypical/Result" ~> 0.4.2
+github "antitypical/Result" ~> 0.5

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,1 @@
-github "robrix/Box" "1.2.2"
-github "antitypical/Result" "0.4.3"
+github "antitypical/Result" "0.5"

--- a/Documentation/Migration_2.0.md
+++ b/Documentation/Migration_2.0.md
@@ -1,8 +1,8 @@
-BrightFutures 2.0 has two new dependencies: Result and Box. If you're using CocoaPods, `pod update` should automatically integrate it into your project. If you're using Carthage, after running `carthage update`, you need to add `Result.framework` and `Box.framework` to your target like you have also done for `BrightFutures.framework`. 
+BrightFutures 2.0 has a new dependency: Result. If you're using CocoaPods, `pod update` should automatically integrate it into your project. If you're using Carthage, after running `carthage update`, you need to add `Result.framework` to your target like you have also done for `BrightFutures.framework`. 
 
-In files where you're using `Result` or `Box`, you'll also need to add an import statement for the respecive frameworks. If you fail to do this, you will see errors like "Use of undeclared type 'Result'".
+In files where you're using `Result`, you'll also need to add an import statement for the respecive frameworks. If you fail to do this, you will see errors like "Use of undeclared type 'Result'".
 
-If you see error messages around `import Result` or `import Box`, the new dependencies have not yet been integrated correctly.
+If you see error messages around `import Result`, the new dependencies have not yet been integrated correctly.
 
 `Future` and `Result` in BrightFutures 1.0 have only one generic parameter: the value type. In BrightFutures 2.0, both types have gained a second generic parameter: the error type. This removes the dependency on `NSError`. If you want to continue to use `NSError`, this means that you'll have to go through your code and update the occurrences of `Future` and `Result`
 
@@ -22,7 +22,7 @@ If you have been using `Future<Void>` in cases where you know the future will ne
 
 If you have futures that you know can never fail, consider using the `NoError` as the error type. Like `NoValue`, `NoError` cannot be instantiated.
 
-The easiest way to create `Result` instances is through its two constructors. You won't need to use `Box` then:
+The easiest way to create `Result` instances is through its two constructors.
 
 ```swift
 Result(success: 1314) // a Result.Success


### PR DESCRIPTION
- add Swift 2.0 and Xcode 7 support
- use `ErrorType` provided from Apple 
- remove `nsError` from `ErrorType` (knowing that a _domain, _code is provided when conforming to `ErrorType` so it's easy to build an `NSError` from it (aka: ` NSError(domain: _domain, code: _code, userInfo: nil)`
- upgrade `Result` to a version that no longer has `Box` (thanks to Swift 2.0)