### PR TITLE
Swift and Xcode 7 beta 3 compatibility fix

### DIFF
--- a/BrightFutures/Async.swift
+++ b/BrightFutures/Async.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public class Async<Value>: AsyncType {
+public class Async<Value>: MutableAsyncType, CustomStringConvertible, CustomDebugStringConvertible {
 
     typealias CompletionCallback = Value -> Void
     
@@ -99,14 +99,14 @@ public class Async<Value>: AsyncType {
         return self
     }
     
-}
-
-extension Async: MutableAsyncType { }
-
-extension Async: CustomStringConvertible, CustomDebugStringConvertible {
+    // MARK: CustomStringConvertible
+    
     public var description: String {
         return "Async<\(Value.self)>(\(self.value))"
     }
+    
+    
+    // MARK: CustomDebugStringConvertible
     
     public var debugDescription: String {
         return description


### PR DESCRIPTION
fixing: 
```
Async.swift:104:18: Redundant conformance of 'Async<Value>' to protocol 'MutableAsyncType'

```
and:
```
Async.swift:106:18: Redundant conformance of 'Async<Value>' to protocol 'CustomStringConvertible'

Async.swift:106:43: Redundant conformance of 'Async<Value>' to protocol 'CustomDebugStringConvertible'

```