### PR TITLE
Implement Xcode 7.1 explicit capture semantics

### DIFF
--- a/BrightFutures/AsyncType.swift
+++ b/BrightFutures/AsyncType.swift
@@ -77,7 +77,7 @@ public extension AsyncType {
     public func delay(queue: Queue, interval: NSTimeInterval) -> Self {
         return Self { complete in
             queue.after(.In(interval)) {
-                onComplete(ImmediateExecutionContext, callback: complete)
+                self.onComplete(ImmediateExecutionContext, callback: complete)
             }
         }
     }


### PR DESCRIPTION
This minor change fixes a warning that springs up in Xcode 7.1 beta 2 (7B75) on the `swift-2.0` branch:

![image](https://cloud.githubusercontent.com/assets/47405/10255597/7b067b9e-6919-11e5-9b9f-d9b6b5232d0d.png)