### PR TITLE
Force unwrap optional for forced without timeout

### DIFF
--- a/BrightFutures/AsyncType.swift
+++ b/BrightFutures/AsyncType.swift
@@ -29,10 +29,9 @@ public extension AsyncType {
     }
     
     /// Blocks the current thread until the future is completed and then returns the result
-    public func forced() -> Value? {
-        return forced(TimeInterval.Forever)
+    public func forced() -> Value {
+        return forced(TimeInterval.Forever)!
     }
-    
     
     /// See `forced(timeout: TimeInterval) -> Value?`
     public func forced(timeout: NSTimeInterval) -> Value? {


### PR DESCRIPTION
AsyncType.forced() without a timeout is guaranteed to return a non-nil value, so it would be helpful to not require unwrapping at the call site.