### PR TITLE
incomplete Futures are not failed

### DIFF
--- a/BrightFutures/AsyncType+ResultType.swift
+++ b/BrightFutures/AsyncType+ResultType.swift
@@ -15,7 +15,7 @@ public extension AsyncType where Value: ResultType {
     
     /// `true` if the future failed, or `false` otherwise
     public var isFailure: Bool {
-        return !isSuccess
+        return result?.analysis(ifSuccess: { _ in return false }, ifFailure: { _ in return true }) ?? false
     }
     
     public var value: Value.Value? {


### PR DESCRIPTION
Previously, if !future.isCompleted, then future.isFailure was always true.  Futures shouldn't be neither success nor failure until completed.