### PR TITLE
Allow consumers to set DefaultThreadingModel to a synchronous one

### DIFF
--- a/BrightFutures.xcodeproj/project.pbxproj
+++ b/BrightFutures.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		346151721C2A063800C5E9F8 /* DefaultThreadingModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346151711C2A063800C5E9F8 /* DefaultThreadingModelTests.swift */; };
+		346151731C2A063800C5E9F8 /* DefaultThreadingModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346151711C2A063800C5E9F8 /* DefaultThreadingModelTests.swift */; };
+		346151741C2A063800C5E9F8 /* DefaultThreadingModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346151711C2A063800C5E9F8 /* DefaultThreadingModelTests.swift */; };
 		E9039ADD1A45DF8D000DD6F1 /* ResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9039ADC1A45DF8D000DD6F1 /* ResultTests.swift */; };
 		E907D1DE1A6AE4A000AB8075 /* Semaphore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E907D1DD1A6AE4A000AB8075 /* Semaphore.swift */; };
 		E9319EA41A397D2C00A0604A /* QueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9319EA31A397D2C00A0604A /* QueueTests.swift */; };
@@ -153,6 +156,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		346151711C2A063800C5E9F8 /* DefaultThreadingModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultThreadingModelTests.swift; sourceTree = "<group>"; };
 		E9039ADC1A45DF8D000DD6F1 /* ResultTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultTests.swift; sourceTree = "<group>"; };
 		E907D1DD1A6AE4A000AB8075 /* Semaphore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Semaphore.swift; sourceTree = "<group>"; };
 		E9319EA31A397D2C00A0604A /* QueueTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueueTests.swift; sourceTree = "<group>"; };
@@ -363,6 +367,7 @@
 				E9F69BA11B93384800713A91 /* SemaphoreTests.swift */,
 				E99397C31BAD49EC00A0B077 /* NSOperationQueueTests.swift */,
 				E9DF0825194470060083F7F2 /* Supporting Files */,
+				346151711C2A063800C5E9F8 /* DefaultThreadingModelTests.swift */,
 			);
 			path = BrightFuturesTests;
 			sourceTree = "<group>";
@@ -665,6 +670,7 @@
 				E98647C51BF3288D00B6BEEE /* QueueTests.swift in Sources */,
 				E98647C61BF3288D00B6BEEE /* ResultTests.swift in Sources */,
 				E98647CA1BF3288D00B6BEEE /* SemaphoreTests.swift in Sources */,
+				346151741C2A063800C5E9F8 /* DefaultThreadingModelTests.swift in Sources */,
 				E98647C41BF3288D00B6BEEE /* PromiseTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -725,6 +731,7 @@
 				E9D45B221AF00676000F6CA7 /* QueueTests.swift in Sources */,
 				E9E422CA1B1FA5300000558F /* ExecutionContextTests.swift in Sources */,
 				E9D45B231AF00676000F6CA7 /* ResultTests.swift in Sources */,
+				346151731C2A063800C5E9F8 /* DefaultThreadingModelTests.swift in Sources */,
 				E9F69BA31B93384800713A91 /* SemaphoreTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -763,6 +770,7 @@
 				E9DF0828194470060083F7F2 /* BrightFuturesTests.swift in Sources */,
 				E9E422C91B1FA5300000558F /* ExecutionContextTests.swift in Sources */,
 				E9319EA41A397D2C00A0604A /* QueueTests.swift in Sources */,
+				346151721C2A063800C5E9F8 /* DefaultThreadingModelTests.swift in Sources */,
 				E9F69BA21B93384800713A91 /* SemaphoreTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1212,6 +1220,7 @@
 				E98647AF1BF327E400B6BEEE /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		E98647B31BF327E400B6BEEE /* Build configuration list for PBXNativeTarget "BrightFutures-tvOSTests" */ = {
 			isa = XCConfigurationList;
@@ -1220,6 +1229,7 @@
 				E98647B11BF327E400B6BEEE /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		E9CBFD171B8268FB00702394 /* Build configuration list for PBXNativeTarget "BrightFutures-watchOS" */ = {
 			isa = XCConfigurationList;

--- a/BrightFutures/Async.swift
+++ b/BrightFutures/Async.swift
@@ -75,7 +75,7 @@ public class Async<Value>: AsyncType {
     /// Adds the given closure as a callback for when the Async completes. The closure is executed on the given context.
     /// If no context is given, the behavior is defined by the default threading model (see README.md)
     /// Returns self
-    public func onComplete(context: ExecutionContext = DefaultThreadingModel(), callback: Value -> Void) -> Self {
+    public func onComplete(context: ExecutionContext = DefaultThreadingModel.context, callback: Value -> Void) -> Self {
         let wrappedCallback : Value -> Void = { [weak self] value in
             let a = self // this is a workaround for a compiler segfault
             

--- a/BrightFutures/AsyncType+ResultType.swift
+++ b/BrightFutures/AsyncType+ResultType.swift
@@ -29,7 +29,7 @@ public extension AsyncType where Value: ResultType {
     /// Adds the given closure as a callback for when the future succeeds. The closure is executed on the given context.
     /// If no context is given, the behavior is defined by the default threading model (see README.md)
     /// Returns self
-    public func onSuccess(context: ExecutionContext = DefaultThreadingModel(), callback: Value.Value -> Void) -> Self {
+    public func onSuccess(context: ExecutionContext = DefaultThreadingModel.context, callback: Value.Value -> Void) -> Self {
         self.onComplete(context) { result in
             result.analysis(ifSuccess: callback, ifFailure: { _ in })
         }
@@ -40,7 +40,7 @@ public extension AsyncType where Value: ResultType {
     /// Adds the given closure as a callback for when the future fails. The closure is executed on the given context.
     /// If no context is given, the behavior is defined by the default threading model (see README.md)
     /// Returns self
-    public func onFailure(context: ExecutionContext = DefaultThreadingModel(), callback: Value.Error -> Void) -> Self {
+    public func onFailure(context: ExecutionContext = DefaultThreadingModel.context, callback: Value.Error -> Void) -> Self {
         self.onComplete(context) { result in
             result.analysis(ifSuccess: { _ in }, ifFailure: callback)
         }
@@ -63,7 +63,7 @@ public extension AsyncType where Value: ResultType {
     /// See `flatMap<U>(context c: ExecutionContext, f: T -> Future<U, E>) -> Future<U, E>`
     /// The given closure is executed according to the default threading model (see README.md)
     public func flatMap<U>(f: Value.Value -> Future<U, Value.Error>) -> Future<U, Value.Error> {
-        return flatMap(DefaultThreadingModel(), f: f)
+        return flatMap(DefaultThreadingModel.context, f: f)
     }
     
     /// Transforms the given closure returning `Result<U>` to a closure returning `Future<U>` and then calls
@@ -77,13 +77,13 @@ public extension AsyncType where Value: ResultType {
     /// See `flatMap<U>(context c: ExecutionContext, f: T -> Result<U, E>) -> Future<U, E>`
     /// The given closure is executed according to the default threading model (see README.md)
     public func flatMap<U>(f: Value.Value -> Result<U, Value.Error>) -> Future<U, Value.Error> {
-        return flatMap(DefaultThreadingModel(), f: f)
+        return flatMap(DefaultThreadingModel.context, f: f)
     }
     
     /// See `map<U>(context c: ExecutionContext, f: (T) -> U) -> Future<U>`
     /// The given closure is executed according to the default threading model (see README.md)
     public func map<U>(f: Value.Value -> U) -> Future<U, Value.Error> {
-        return self.map(DefaultThreadingModel(), f: f)
+        return self.map(DefaultThreadingModel.context, f: f)
     }
     
     /// Returns a future that succeeds with the value returned from the given closure when it is invoked with the success value
@@ -104,7 +104,7 @@ public extension AsyncType where Value: ResultType {
     /// Returns a future that completes with this future if this future succeeds or with the value returned from the given closure
     /// when it is invoked with the error that this future failed with.
     /// The closure is executed on the given context. If no context is given, the behavior is defined by the default threading model (see README.md)
-    public func recover(context c: ExecutionContext = DefaultThreadingModel(), task: Value.Error -> Value.Value) -> Future<Value.Value, NoError> {
+    public func recover(context c: ExecutionContext = DefaultThreadingModel.context, task: Value.Error -> Value.Value) -> Future<Value.Value, NoError> {
         return self.recoverWith(context: c) { error -> Future<Value.Value, NoError> in
             return Future<Value.Value, NoError>(value: task(error))
         }
@@ -115,7 +115,7 @@ public extension AsyncType where Value: ResultType {
     /// This function should be used in cases where there are two asynchronous operations where the second operation (returned from the given closure)
     /// should only be executed if the first (this future) fails.
     /// The closure is executed on the given context. If no context is given, the behavior is defined by the default threading model (see README.md)
-    public func recoverWith<E1: ErrorType>(context c: ExecutionContext = DefaultThreadingModel(), task: Value.Error -> Future<Value.Value, E1>) -> Future<Value.Value, E1> {
+    public func recoverWith<E1: ErrorType>(context c: ExecutionContext = DefaultThreadingModel.context, task: Value.Error -> Future<Value.Value, E1>) -> Future<Value.Value, E1> {
         let res = Future<Value.Value, E1>()
         
         self.onComplete(c) { result in
@@ -130,7 +130,7 @@ public extension AsyncType where Value: ResultType {
     /// See `mapError<E1>(context c: ExecutionContext, f: E -> E1) -> Future<T, E1>`
     /// The given closure is executed according to the default threading model (see README.md)
     public func mapError<E1: ErrorType>(f: Value.Error -> E1) -> Future<Value.Value, E1> {
-        return mapError(DefaultThreadingModel(), f: f)
+        return mapError(DefaultThreadingModel.context, f: f)
     }
     
     /// Returns a future that fails with the error returned from the given closure when it is invoked with the error
@@ -151,7 +151,7 @@ public extension AsyncType where Value: ResultType {
     /// Adds the given closure as a callback for when this future completes.
     /// The closure is executed on the given context. If no context is given, the behavior is defined by the default threading model (see README.md)
     /// Returns a future that completes with the result from this future but only after executing the given closure
-    public func andThen(context c: ExecutionContext = DefaultThreadingModel(), callback: Self.Value -> Void) -> Self {
+    public func andThen(context c: ExecutionContext = DefaultThreadingModel.context, callback: Self.Value -> Void) -> Self {
         return Self { complete in
             onComplete(c) { result in
                 callback(result)

--- a/BrightFutures/ExecutionContext.swift
+++ b/BrightFutures/ExecutionContext.swift
@@ -50,9 +50,22 @@ public func toContext(queue: dispatch_queue_t) -> ExecutionContext {
     return Queue(queue: queue).context
 }
 
-typealias ThreadingModel = () -> ExecutionContext
+/// Defines BrightFutures' default threading behaviour, by default this is
+/// set to `StandardThreadingModel.AsynchronousOnCurrentThread`
+public var DefaultThreadingModel: StandardThreadingModel = .AsynchronousOnCurrentThread
 
-var DefaultThreadingModel: ThreadingModel = defaultContext
+/// Defines the possibilities for setting the `DefaultThreadingModel`.
+public enum StandardThreadingModel {
+    case AsynchronousOnCurrentThread
+    case Synchronous
+    
+    internal var context: ExecutionContext {
+        switch self {
+        case .AsynchronousOnCurrentThread: return defaultContext()
+        case .Synchronous: return { task in task() }
+        }
+    }
+}
 
 /// Defines BrightFutures' default threading behavior:
 /// - if on the main thread, `Queue.main.context` is returned

--- a/BrightFutures/Future.swift
+++ b/BrightFutures/Future.swift
@@ -108,7 +108,7 @@ public final class Future<T, E: ErrorType>: Async<Result<T, E>> {
 /// Short-hand for `lhs.recover(rhs())`
 /// `rhs` is executed according to the default threading model (see README.md)
 public func ?? <T, E>(lhs: Future<T, E>, @autoclosure(escaping) rhs: () -> T) -> Future<T, NoError> {
-    return lhs.recover(context: DefaultThreadingModel(), task: { _ in
+    return lhs.recover(context: DefaultThreadingModel.context, task: { _ in
         return rhs()
     })
 }
@@ -116,7 +116,7 @@ public func ?? <T, E>(lhs: Future<T, E>, @autoclosure(escaping) rhs: () -> T) ->
 /// Short-hand for `lhs.recoverWith(rhs())`
 /// `rhs` is executed according to the default threading model (see README.md)
 public func ?? <T, E, E1>(lhs: Future<T, E>, @autoclosure(escaping) rhs: () -> Future<T, E1>) -> Future<T, E1> {
-    return lhs.recoverWith(context: DefaultThreadingModel(), task: { _ in
+    return lhs.recoverWith(context: DefaultThreadingModel.context, task: { _ in
         return rhs()
     })
 }

--- a/BrightFutures/InvalidationToken.swift
+++ b/BrightFutures/InvalidationToken.swift
@@ -26,10 +26,10 @@ extension InvalidationTokenType {
     /// Alias of context(parentContext:task:) which uses the default threading model
     /// Due to a limitation of the Swift compiler, we cannot express this with a single method
     public var validContext: ExecutionContext {
-        return validContext(DefaultThreadingModel())
+        return validContext(DefaultThreadingModel.context)
     }
     
-    public func validContext(parentContext: ExecutionContext = DefaultThreadingModel()) -> ExecutionContext {
+    public func validContext(parentContext: ExecutionContext = DefaultThreadingModel.context) -> ExecutionContext {
         return { task in
             parentContext {
                 if !self.isInvalid {

--- a/BrightFuturesTests/DefaultThreadingModelTests.swift
+++ b/BrightFuturesTests/DefaultThreadingModelTests.swift
@@ -1,0 +1,59 @@
+//
+//  DefaultThreadingModelTests.swift
+//  BrightFutures
+//
+//  Created by Matthew Healy on 22/12/2015.
+//  Copyright © 2015 Thomas Visser. All rights reserved.
+//
+
+import XCTest
+@testable import BrightFutures
+
+class DefaultThreadingModelTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        resetDefaultThreadingModel()
+    }
+    
+    override func tearDown() {
+        resetDefaultThreadingModel()
+        super.tearDown()
+    }
+    
+    private func resetDefaultThreadingModel() {
+        DefaultThreadingModel = .AsynchronousOnCurrentThread
+    }
+
+    func test_Synchronous_ContextIsImmediateExecution() {
+        let testee = StandardThreadingModel.Synchronous
+        let context = testee.context
+        var taskRun = false
+        context({ taskRun = true })
+        XCTAssertTrue(taskRun)
+    }
+    
+    func test_AsynchronousOnCurrentThread_ContextIsAsyncExecution() {
+        let testee = StandardThreadingModel.AsynchronousOnCurrentThread
+        let context = testee.context
+        var taskRun = false
+        let isCalledExpectation = expectationWithDescription("Task was run")
+        context({
+            taskRun = true
+            isCalledExpectation.fulfill()
+        })
+        XCTAssertFalse(taskRun, "Task was not run asynchronously")
+        waitForExpectationsWithTimeout(2000, handler: nil)
+    }
+    
+    func test_DefaultThreadingModel_IsAsynchronousOnCurrentThreadByDefault() {
+        let testee = BrightFutures.DefaultThreadingModel
+        XCTAssertEqual(testee, StandardThreadingModel.AsynchronousOnCurrentThread)
+    }
+    
+    func test_DefaultThreadingModel_CanBeSetToSynchronous() {
+        DefaultThreadingModel = .Synchronous
+        XCTAssertEqual(DefaultThreadingModel, StandardThreadingModel.Synchronous)
+    }
+
+}


### PR DESCRIPTION
… for easy testing.

This change implements my idea from #91. 

I didn't go so far as to convert the (currently asynchronous) tests in the `BrightFututesTests.swift` file as part of this commit. I did, however, confirm before opening this pull request that those tests can be made synchronous where appropriate. This should remove a number of unnecessary `waitForExpectation` calls, and therefore speed up the tests.

If you do decide to merge this in then I'll get to work converting the tests asap. :smile: 