### PR TITLE
Convenience Promise init with closure to supply a completion handler

### DIFF
--- a/BrightFutures/AsyncType+ResultType.swift
+++ b/BrightFutures/AsyncType+ResultType.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2015 Thomas Visser. All rights reserved.
 //
 import Result
+import Foundation
 
 public extension AsyncType where Value: ResultType {
     /// `true` if the future completed with success, or `false` otherwise
@@ -263,3 +264,22 @@ public extension AsyncType where Value: ResultType, Value.Value == NoValue {
     }
 }
 
+public extension Async where Value: ResultType, Value.Error: CompletionHandlerErrorType {
+ 
+    public typealias CompletionHandler = (Value.Value?, Value.Error.ExternalErrorType?) -> Void
+    
+    /// Return a closure convenient for asynchronous systems.
+    public func completionHandler() -> CompletionHandler {
+        return { (obj, err) in
+            if let obj = obj {
+                self.success(obj)
+            } else if let err = err {
+                self.failure(Value.Error.ExternalType(err))
+            } else {
+                // closure was called with (nil, nil), assume invalid
+                self.failure(Value.Error.IllegalStateType)
+            }
+        }
+    }
+
+}

--- a/BrightFutures/Errors.swift
+++ b/BrightFutures/Errors.swift
@@ -22,8 +22,6 @@
 
 import Foundation
 
-public let BrightFuturesErrorDomain: String = "thomvis.brightfutures"
-
 /// Can be used as the value type of a `Future` or `Result` to indicate it can never fail.
 /// This is guaranteed by the type system, because `NoError` has no possible values and thus cannot be created.
 public enum NoError {}
@@ -60,5 +58,26 @@ public func ==<E: Equatable>(lhs: BrightFuturesError<E>, rhs: BrightFuturesError
     case (.InvalidationTokenInvalidated, .InvalidationTokenInvalidated): return true
     case (.External(let lhs), .External(let rhs)): return lhs == rhs
     default: return false
+    }
+}
+
+// Error type that can be used to create a completion handler, useful to adapt to 
+// future to asynchronous code
+public protocol CompletionHandlerErrorType: ErrorType {
+    typealias ExternalErrorType = ErrorType
+    
+    static var IllegalStateType: Self {get}
+    static func ExternalType(error: ExternalErrorType) -> Self
+}
+
+extension BrightFuturesError: CompletionHandlerErrorType {
+    public typealias ExternalErrorType = E
+
+    public static var IllegalStateType: BrightFuturesError {
+        return .IllegalState
+    }
+
+    public static func ExternalType(error: ExternalErrorType) -> BrightFuturesError {
+        return .External(error)
     }
 }

--- a/BrightFutures/Errors.swift
+++ b/BrightFutures/Errors.swift
@@ -22,6 +22,8 @@
 
 import Foundation
 
+public let BrightFuturesErrorDomain: String = "thomvis.brightfutures"
+
 /// Can be used as the value type of a `Future` or `Result` to indicate it can never fail.
 /// This is guaranteed by the type system, because `NoError` has no possible values and thus cannot be created.
 public enum NoError {}

--- a/BrightFutures/Future.swift
+++ b/BrightFutures/Future.swift
@@ -102,7 +102,16 @@ public final class Future<T, E: ErrorType>: Async<Result<T, E>> {
     public required init(@noescape resolver: (result: Value -> Void) -> Void) {
         super.init(resolver: resolver)
     }
-    
+
+}
+
+public extension Future where E: CompletionHandlerErrorType {
+
+    public convenience init(@noescape resolver: (CompletionHandler) -> Void) {
+        self.init()
+        resolver(self.completionHandler())
+    }
+
 }
 
 /// Short-hand for `lhs.recover(rhs())`

--- a/BrightFutures/Promise.swift
+++ b/BrightFutures/Promise.swift
@@ -81,3 +81,29 @@ public class Promise<T, E: ErrorType> {
     }
     
 }
+
+extension Promise where E: NSError {
+
+    /// Creates a new promise with a pending future,
+    /// and pass a closure convenient to wrap with asynchronous systems.
+    public convenience init(completionHandled: (((T?, E?) -> Void)) -> Void) {
+        self.init()
+        completionHandled(self.completionHandler())
+    }
+
+    /// Return a closure convenient for asynchronous systems.
+    public func completionHandler() -> ((T?, E?) -> Void) {
+        return { (obj, err) in
+            if let obj = obj {
+                self.success(obj)
+            } else if let err = err {
+                self.failure(err)
+            } else {
+                // closure was called with (nil, nil), assume invalid
+                let userInfo = [NSLocalizedDescriptionKey: "Invalid call of complention closure with (nil, nil)"]
+                self.failure(E(domain: BrightFuturesErrorDomain, code: 1, userInfo: userInfo))
+            }
+        }
+    }
+
+}

--- a/BrightFutures/Promise.swift
+++ b/BrightFutures/Promise.swift
@@ -81,29 +81,3 @@ public class Promise<T, E: ErrorType> {
     }
     
 }
-
-extension Promise where E: NSError {
-
-    /// Creates a new promise with a pending future,
-    /// and pass a closure convenient to wrap with asynchronous systems.
-    public convenience init(completionHandled: (((T?, E?) -> Void)) -> Void) {
-        self.init()
-        completionHandled(self.completionHandler())
-    }
-
-    /// Return a closure convenient for asynchronous systems.
-    public func completionHandler() -> ((T?, E?) -> Void) {
-        return { (obj, err) in
-            if let obj = obj {
-                self.success(obj)
-            } else if let err = err {
-                self.failure(err)
-            } else {
-                // closure was called with (nil, nil), assume invalid
-                let userInfo = [NSLocalizedDescriptionKey: "Invalid call of complention closure with (nil, nil)"]
-                self.failure(E(domain: BrightFuturesErrorDomain, code: 1, userInfo: userInfo))
-            }
-        }
-    }
-
-}

--- a/BrightFuturesTests/BrightFuturesTests.swift
+++ b/BrightFuturesTests/BrightFuturesTests.swift
@@ -1153,62 +1153,123 @@ extension BrightFuturesTests {
 * This extension contains all tests related to completionHandler()
 */
 extension BrightFuturesTests {
-    
-    
+
     func testCompletionHandlerWithValue() {
         let e = self.expectation()
         
-        let promise = Promise<Int, NSError>()
+        let future = Future<Int, BrightFuturesError<NSError>>()
         
-        let handler = promise.completionHandler()
+        let handler = future.completionHandler()
         handler(5, nil)
-        promise.future.onSuccess { value in
+        future.onSuccess { value in
             e.fulfill()
         }
-        promise.future.onFailure { err in
+        future.onFailure { err in
             XCTFail("Must not failed")
         }
         
         self.waitForExpectationsWithTimeout(2, handler: nil)
     }
-    
+
     func testCompletionHandlerWithError() {
         let e = self.expectation()
         
-        let promise = Promise<Int, NSError>()
+        let future = Future<Int, BrightFuturesError<NSError>>()
         
-        let handler = promise.completionHandler()
+        let handler = future.completionHandler()
         
         let error = NSError(domain: "test", code: 0, userInfo: nil)
         handler(nil, error)
-        promise.future.onSuccess { value in
+        future.onSuccess { value in
             XCTFail("Must not succeed")
         }
-        promise.future.onFailure { err in
-            XCTAssertEqual(error, err)
+        future.onFailure { (err: BrightFuturesError) in
+            switch err {
+            case .External(let e):
+                XCTAssertEqual(error, e)
+            default:
+                XCTFail("Wrong error type \(err)")
+            }
             e.fulfill()
         }
         
         self.waitForExpectationsWithTimeout(2, handler: nil)
     }
-    
+
     func testCompletionHandlerNilNilError() {
         let e = self.expectation()
         
-        let promise = Promise<Int, NSError>()
+        let future = Future<Int, BrightFuturesError<NSError>>()
         
-        let handler = promise.completionHandler()
+        let handler = future.completionHandler()
         handler(nil, nil)
-        promise.future.onSuccess { value in
+        future.onSuccess { value in
             XCTFail("Must not succeed")
         }
-        promise.future.onFailure { err in
+        future.onFailure { err in
               e.fulfill()
         }
         
         self.waitForExpectationsWithTimeout(2, handler: nil)
     }
-    
+
+    func testCompletionHandlerInitWithValue() {
+        let e = self.expectation()
+
+        let future = Future<Int, BrightFuturesError<NSError>>{
+            self.methodWithCompletionHandler(1, error: nil, completionHandler: $0)
+        }
+        future.onSuccess { value in
+            e.fulfill()
+        }
+        future.onFailure { err in
+            XCTFail("Must not failed")
+        }
+        
+        self.waitForExpectationsWithTimeout(2, handler: nil)
+    }
+
+    func testCompletionHandlerInitWithError() {
+        let e = self.expectation()
+        
+        let error = NSError(domain: "test", code: 0, userInfo: nil)
+      
+        let future = Future<Int, BrightFuturesError<NSError>>{
+            self.methodWithCompletionHandler(nil, error: error, completionHandler: $0)
+        }
+        
+        future.onSuccess { value in
+            XCTFail("Must not succeed")
+        }
+        future.onFailure { (err: BrightFuturesError) in
+            switch err {
+            case .External(let e):
+                XCTAssertEqual(error, e)
+            default:
+                XCTFail("Wrong error type \(err)")
+            }
+            e.fulfill()
+        }
+        
+        self.waitForExpectationsWithTimeout(2, handler: nil)
+    }
+
+    func testCompletionHandlerInitNilNilError() {
+        let e = self.expectation()
+        
+        let future = Future<Int, BrightFuturesError<NSError>>{
+            self.methodWithCompletionHandler(nil, error: nil, completionHandler: $0)
+        }
+        future.onSuccess { value in
+            XCTFail("Must not succeed")
+        }
+        future.onFailure { err in
+            e.fulfill()
+        }
+        
+        self.waitForExpectationsWithTimeout(2, handler: nil)
+    }
+
 }
 
 /**
@@ -1231,6 +1292,11 @@ extension XCTestCase {
             usleep(arc4random_uniform(100))
             return Result(value: val)
         }
+    }
+    
+    
+    func methodWithCompletionHandler(value: Int?, error: NSError?, completionHandler: (value: Int?, error: NSError?) -> Void) {
+        completionHandler(value: value, error: error)
     }
 }
 

--- a/BrightFuturesTests/BrightFuturesTests.swift
+++ b/BrightFuturesTests/BrightFuturesTests.swift
@@ -1148,6 +1148,69 @@ extension BrightFuturesTests {
     
 }
 
+// MARK: Functional Composition
+/**
+* This extension contains all tests related to completionHandler()
+*/
+extension BrightFuturesTests {
+    
+    
+    func testCompletionHandlerWithValue() {
+        let e = self.expectation()
+        
+        let promise = Promise<Int, NSError>()
+        
+        let handler = promise.completionHandler()
+        handler(5, nil)
+        promise.future.onSuccess { value in
+            e.fulfill()
+        }
+        promise.future.onFailure { err in
+            XCTFail("Must not failed")
+        }
+        
+        self.waitForExpectationsWithTimeout(2, handler: nil)
+    }
+    
+    func testCompletionHandlerWithError() {
+        let e = self.expectation()
+        
+        let promise = Promise<Int, NSError>()
+        
+        let handler = promise.completionHandler()
+        
+        let error = NSError(domain: "test", code: 0, userInfo: nil)
+        handler(nil, error)
+        promise.future.onSuccess { value in
+            XCTFail("Must not succeed")
+        }
+        promise.future.onFailure { err in
+            XCTAssertEqual(error, err)
+            e.fulfill()
+        }
+        
+        self.waitForExpectationsWithTimeout(2, handler: nil)
+    }
+    
+    func testCompletionHandlerNilNilError() {
+        let e = self.expectation()
+        
+        let promise = Promise<Int, NSError>()
+        
+        let handler = promise.completionHandler()
+        handler(nil, nil)
+        promise.future.onSuccess { value in
+            XCTFail("Must not succeed")
+        }
+        promise.future.onFailure { err in
+              e.fulfill()
+        }
+        
+        self.waitForExpectationsWithTimeout(2, handler: nil)
+    }
+    
+}
+
 /**
  * This extension contains utility methods used in the tests above
  */


### PR DESCRIPTION
The purpose is to create easily a promise/future for apple framework methods with completion handlers

For instance mapkit method `calculateETAWithCompletionHandler` :
```swift
import MapKit
extension MKDirections {
    public func calculateETA() -> Future<MKETAResponse, NSError> {
        let promise = Promise<MKETAResponse, NSError>()
        self.calculateETAWithCompletionHandler(promise.completionHandler())
        return promise.future
    }
    // or 
    public func calculateETA() -> Future<MKETAResponse, NSError> {
        return Promise<MKETAResponse, NSError> { self.calculateETAWithCompletionHandler($0) }.future
    }
}
```

And then I can PR FutureProofing with some extensions 