### PR TITLE
Allow to create Future and pass a completion handler closure 

### DIFF
--- a/BrightFutures/AsyncType+ResultType.swift
+++ b/BrightFutures/AsyncType+ResultType.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2015 Thomas Visser. All rights reserved.
 //
 import Result
+import Foundation
 
 public extension AsyncType where Value: ResultType {
     /// `true` if the future completed with success, or `false` otherwise
@@ -263,3 +264,22 @@ public extension AsyncType where Value: ResultType, Value.Value == NoValue {
     }
 }
 
+public extension Async where Value: ResultType, Value.Error: CompletionHandlerErrorType {
+ 
+    public typealias CompletionHandler = (Value.Value?, Value.Error.ExternalErrorType?) -> Void
+    
+    /// Return a closure convenient for asynchronous systems.
+    public func completionHandler() -> CompletionHandler {
+        return { (obj, err) in
+            if let obj = obj {
+                self.success(obj)
+            } else if let err = err {
+                self.failure(Value.Error.ExternalType(err))
+            } else {
+                // closure was called with (nil, nil), assume invalid
+                self.failure(Value.Error.IllegalStateType)
+            }
+        }
+    }
+
+}

--- a/BrightFutures/Errors.swift
+++ b/BrightFutures/Errors.swift
@@ -60,3 +60,24 @@ public func ==<E: Equatable>(lhs: BrightFuturesError<E>, rhs: BrightFuturesError
     default: return false
     }
 }
+
+// Error type that can be used to create a completion handler, useful to adapt to 
+// future to asynchronous code
+public protocol CompletionHandlerErrorType: ErrorType {
+    typealias ExternalErrorType = ErrorType
+    
+    static var IllegalStateType: Self {get}
+    static func ExternalType(error: ExternalErrorType) -> Self
+}
+
+extension BrightFuturesError: CompletionHandlerErrorType {
+    public typealias ExternalErrorType = E
+
+    public static var IllegalStateType: BrightFuturesError {
+        return .IllegalState
+    }
+
+    public static func ExternalType(error: ExternalErrorType) -> BrightFuturesError {
+        return .External(error)
+    }
+}

--- a/BrightFutures/Future.swift
+++ b/BrightFutures/Future.swift
@@ -102,7 +102,16 @@ public final class Future<T, E: ErrorType>: Async<Result<T, E>> {
     public required init(@noescape resolver: (result: Value -> Void) -> Void) {
         super.init(resolver: resolver)
     }
-    
+
+}
+
+public extension Future where E: CompletionHandlerErrorType {
+
+    public convenience init(@noescape resolver: (CompletionHandler) -> Void) {
+        self.init()
+        resolver(self.completionHandler())
+    }
+
 }
 
 /// Short-hand for `lhs.recover(rhs())`

--- a/BrightFuturesTests/BrightFuturesTests.swift
+++ b/BrightFuturesTests/BrightFuturesTests.swift
@@ -1148,6 +1148,130 @@ extension BrightFuturesTests {
     
 }
 
+// MARK: Functional Composition
+/**
+* This extension contains all tests related to completionHandler()
+*/
+extension BrightFuturesTests {
+
+    func testCompletionHandlerWithValue() {
+        let e = self.expectation()
+        
+        let future = Future<Int, BrightFuturesError<NSError>>()
+        
+        let handler = future.completionHandler()
+        handler(5, nil)
+        future.onSuccess { value in
+            e.fulfill()
+        }
+        future.onFailure { err in
+            XCTFail("Must not failed")
+        }
+        
+        self.waitForExpectationsWithTimeout(2, handler: nil)
+    }
+
+    func testCompletionHandlerWithError() {
+        let e = self.expectation()
+        
+        let future = Future<Int, BrightFuturesError<NSError>>()
+        
+        let handler = future.completionHandler()
+        
+        let error = NSError(domain: "test", code: 0, userInfo: nil)
+        handler(nil, error)
+        future.onSuccess { value in
+            XCTFail("Must not succeed")
+        }
+        future.onFailure { (err: BrightFuturesError) in
+            switch err {
+            case .External(let e):
+                XCTAssertEqual(error, e)
+            default:
+                XCTFail("Wrong error type \(err)")
+            }
+            e.fulfill()
+        }
+        
+        self.waitForExpectationsWithTimeout(2, handler: nil)
+    }
+
+    func testCompletionHandlerNilNilError() {
+        let e = self.expectation()
+        
+        let future = Future<Int, BrightFuturesError<NSError>>()
+        
+        let handler = future.completionHandler()
+        handler(nil, nil)
+        future.onSuccess { value in
+            XCTFail("Must not succeed")
+        }
+        future.onFailure { err in
+              e.fulfill()
+        }
+        
+        self.waitForExpectationsWithTimeout(2, handler: nil)
+    }
+
+    func testCompletionHandlerInitWithValue() {
+        let e = self.expectation()
+
+        let future = Future<Int, BrightFuturesError<NSError>>{
+            self.methodWithCompletionHandler(1, error: nil, completionHandler: $0)
+        }
+        future.onSuccess { value in
+            e.fulfill()
+        }
+        future.onFailure { err in
+            XCTFail("Must not failed")
+        }
+        
+        self.waitForExpectationsWithTimeout(2, handler: nil)
+    }
+
+    func testCompletionHandlerInitWithError() {
+        let e = self.expectation()
+        
+        let error = NSError(domain: "test", code: 0, userInfo: nil)
+      
+        let future = Future<Int, BrightFuturesError<NSError>>{
+            self.methodWithCompletionHandler(nil, error: error, completionHandler: $0)
+        }
+        
+        future.onSuccess { value in
+            XCTFail("Must not succeed")
+        }
+        future.onFailure { (err: BrightFuturesError) in
+            switch err {
+            case .External(let e):
+                XCTAssertEqual(error, e)
+            default:
+                XCTFail("Wrong error type \(err)")
+            }
+            e.fulfill()
+        }
+        
+        self.waitForExpectationsWithTimeout(2, handler: nil)
+    }
+
+    func testCompletionHandlerInitNilNilError() {
+        let e = self.expectation()
+        
+        let future = Future<Int, BrightFuturesError<NSError>>{
+            self.methodWithCompletionHandler(nil, error: nil, completionHandler: $0)
+        }
+        future.onSuccess { value in
+            XCTFail("Must not succeed")
+        }
+        future.onFailure { err in
+            e.fulfill()
+        }
+        
+        self.waitForExpectationsWithTimeout(2, handler: nil)
+    }
+
+}
+
 /**
  * This extension contains utility methods used in the tests above
  */
@@ -1168,6 +1292,11 @@ extension XCTestCase {
             usleep(arc4random_uniform(100))
             return Result(value: val)
         }
+    }
+    
+    
+    func methodWithCompletionHandler(value: Int?, error: NSError?, completionHandler: (value: Int?, error: NSError?) -> Void) {
+        completionHandler(value: value, error: error)
     }
 }
 


### PR DESCRIPTION
to an asynchronous code

(Sorry I recreate my branch and PR #112 has been closed)

The purpose is to create easily a future for apple framework methods with completion handlers

For instance mapkit method `calculateETAWithCompletionHandler` :
```swift
import MapKit
extension MKDirections {
    public func calculateETA() -> Future<MKETAResponse, BrightFuturesError<NSError>> {
        let future = Future<MKETAResponse, BrightFuturesError<NSError>>()
        self.calculateETAWithCompletionHandler(future.completionHandler())
        return future
    }
    // or 
    public func calculateETA() -> Future<MKETAResponse, BrightFuturesError<NSError>> {
        return Future<MKETAResponse, BrightFuturesError<NSError>> {
            self.calculateETAWithCompletionHandler($0)
        }
    }
}
```
And then I can PR FutureProofing with some extensions that I already implemented

I was able to extend `Future` only using the `CompletionHandlerErrorType`, not concret type `BrightFuturesError`
