### PR TITLE
Added a wrapper around functions with result based completion blocks

### DIFF
--- a/BrightFutures/Future.swift
+++ b/BrightFutures/Future.swift
@@ -101,6 +101,16 @@ public func future<T>(method: (T -> Void) -> Void) -> Future<T, NoError> {
     })
 }
 
+/// Can be used to wrap a typical Result-based API
+/// The completionHandler should have one parameter: A Result Type
+public func future<T, E>(method: ((Result<T, E>) -> Void) -> Void) -> Future<T, E> {
+    return Future(resolver: { completion -> Void in
+        method { result in
+            completion(result)
+        }
+    })
+}
+
 /// A Future represents the outcome of an asynchronous operation
 /// The outcome will be represented as an instance of the `Result` enum and will be stored
 /// in the `result` property. As long as the operation is not yet completed, `result` will be nil.

--- a/BrightFuturesTests/BrightFuturesTests.swift
+++ b/BrightFuturesTests/BrightFuturesTests.swift
@@ -364,6 +364,22 @@ extension BrightFuturesTests {
         let f2 = future { testCall(2, completionHandler: $0) }
         XCTAssert(f2.error == TestError.JustAnError)
     }
+    
+    func testWrapResultCompletionHandlerValue() {
+        func testCall(val: Int, completionHandler: Result<Int,NSError> -> Void) {
+            completionHandler(.Success(val))
+        }
+        
+        func testCall2(val: Int, completionHandler: Result<Int,TestError> -> Void) {
+            completionHandler(.Failure(.JustAnError))
+        }
+        
+        let f = future { testCall(3, completionHandler: $0) }
+        XCTAssertEqual(f.value!, 3)
+        
+        let f2 = future { testCall2(4, completionHandler:  $0) }
+        XCTAssert(f2.error! == .JustAnError)
+    }
 }
 
 // MARK: Functional Composition


### PR DESCRIPTION
I found the new methods you added to wrap Cocoa based completion blocks so useful, that I wrote one to wrap around all the frameworks that use `Result` type completion block.
This means that using a simple `extension`/`protocol extension`, one can transform a `Result` completion based api to a promise based for new methods, while maintaining backwards compatibility with a need for large code re-writes.