### PR TITLE
Add `filter(_:orElse:)` which takes a parameter for the failure error

### DIFF
--- a/BrightFuturesTests/BrightFuturesTests.swift
+++ b/BrightFuturesTests/BrightFuturesTests.swift
@@ -662,6 +662,43 @@ extension BrightFuturesTests {
         self.waitForExpectationsWithTimeout(2, handler: nil)
     }
 
+    func testFilterOrElseNoSuchElement() {
+        let e = self.expectation()
+        Future<Int, TestError>(value: 3).filter({ $0 > 5 }, orElse: TestError.JustAnError).onComplete { result in
+            if let err = result.error {
+                XCTAssert(err == TestError.JustAnError, "filter should yield the orElse error")
+            }
+
+            e.fulfill()
+        }
+        self.waitForExpectationsWithTimeout(2, handler: nil)
+    }
+
+    func testFilterOrElsePasses() {
+        let e = self.expectation()
+        Future<String, TestError>(value: "Thomas").filter({ $0.hasPrefix("Th") }, orElse: TestError.JustAnError).onComplete { result in
+            if let val = result.value {
+                XCTAssert(val == "Thomas", "Filter should pass")
+            }
+
+            e.fulfill()
+        }
+
+        self.waitForExpectationsWithTimeout(2, handler: nil)
+    }
+
+    func testFilterOrElseFailedFuture() {
+        let f = Future<Int, TestError>(error: TestError.JustAnError)
+
+        let e = self.expectation()
+        f.filter({ _ in false }, orElse: TestError.JustAnotherError).onFailure { error in
+            XCTAssert(error == TestError.JustAnError)
+            e.fulfill()
+        }
+
+        self.waitForExpectationsWithTimeout(2, handler: nil)
+    }
+
     func testForcedFuture() {
         var x = 10
         let f: Future<Void, NoError> = future { () -> Void in


### PR DESCRIPTION
The type of the `filter` BrightFutures already has is

    Future<V, E> -> (V -> Bool) -> Future<V, BrightFuturesError<E>>

That's annoying if you want to use `filter` in a chain of operations that share the same error type: `a.flatMap(b).flatMap(c).filter(p).flatMap(d)` where all the error types of `a,b,c` match. Suddenly `d` has to fail with a `BrightFuturesError<E>` instead of the `E` the others do: and if we have another `filter` somewhere in the chain we get `BrightFuturesError<BrightFuturesError<E>>`... A prettier solution at the type level is to convert filter-failure into an error, but one that matches the error type of the chain.

(Side note: this will get more compelling when generic typealiases land: `typealias NetworkOp<A, B> = A -> Future<B, NetworkErrorEnum>`.)

One can sort of work around this with `mapError` but it's rather ugly:

    a.filter(p).mapError { error in
        switch error {
        case .NoSuchElement:
            return .MyOwnErrorCase
        case .External(let originalError):
            return originalError
        default: // trust the BrightFutures docs that this won't happen (ouch)
            fatalError("Oops oh well")
        }
    }

This `filter` version instead lets you specify the error to return when the filter predicate fails. I called the argument `orElse:` for no very compelling reason.