### PR TITLE
Chain AsyncType.delay() sequentially rather than in parallel

### DIFF
--- a/BrightFutures/AsyncType.swift
+++ b/BrightFutures/AsyncType.swift
@@ -75,8 +75,10 @@ public extension AsyncType {
     /// queue.
     public func delay(queue: Queue, interval: NSTimeInterval) -> Self {
         return Self { complete in
-            queue.after(.In(interval)) {
-                self.onComplete(ImmediateExecutionContext, callback: complete)
+            onComplete(ImmediateExecutionContext) { result in
+                queue.after(.In(interval)) {
+                    complete(result)
+                }
             }
         }
     }

--- a/BrightFuturesTests/BrightFuturesTests.swift
+++ b/BrightFuturesTests/BrightFuturesTests.swift
@@ -720,6 +720,21 @@ extension BrightFuturesTests {
         self.waitForExpectationsWithTimeout(2, handler: nil)
     }
     
+    func testDelayChaining() {
+        let e = self.expectation()
+        let t0 = CACurrentMediaTime()
+        future { return }
+            .delay(1)
+            .andThen { _ in XCTAssert(CACurrentMediaTime() - t0 >= 1) }
+            .delay(1)
+            .andThen { _ in
+                XCTAssert(CACurrentMediaTime() - t0 >= 2)
+                e.fulfill()
+            }
+
+        self.waitForExpectationsWithTimeout(3, handler: nil)
+    }
+
     func testFlatMap() {
         let e = self.expectation()
         


### PR DESCRIPTION
Hey, it was surprising that `delay()` operated in parallel, eg

    let t0 = CACurrentMediaTime()
    future { return }
        .delay(1)
        .andThen { _ in print("\(CACurrentMediaTime() - t0) sec" }
        .delay(1)
        .andThen { _ in print("\(CACurrentMediaTime() - t0) sec" }

yields

    1 sec
    1 sec

This pull request modifies `delay()` so that the above example yields

    1 sec
    2 sec

I'm new to the library, so feel free to suggest changes or reject. Thanks!