### PR TITLE
Update for Xcode 8 beta 6

### DIFF
--- a/BrightFutures.xcodeproj/project.pbxproj
+++ b/BrightFutures.xcodeproj/project.pbxproj
@@ -1147,6 +1147,7 @@
 				PRODUCT_NAME = BrightFutures;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -1171,6 +1172,7 @@
 				PRODUCT_NAME = BrightFutures;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/BrightFutures/AsyncType+ResultType.swift
+++ b/BrightFutures/AsyncType+ResultType.swift
@@ -30,7 +30,7 @@ public extension AsyncType where Value: ResultProtocol {
     /// If no context is given, the behavior is defined by the default threading model (see README.md)
     /// Returns self
     @discardableResult
-    public func onSuccess(_ context: ExecutionContext = DefaultThreadingModel(), callback: (Value.Value) -> Void) -> Self {
+    public func onSuccess(_ context: ExecutionContext = DefaultThreadingModel(), callback: @escaping (Value.Value) -> Void) -> Self {
         self.onComplete(context) { result in
             result.analysis(ifSuccess: callback, ifFailure: { _ in })
         }
@@ -42,7 +42,7 @@ public extension AsyncType where Value: ResultProtocol {
     /// If no context is given, the behavior is defined by the default threading model (see README.md)
     /// Returns self
     @discardableResult
-    public func onFailure(_ context: ExecutionContext = DefaultThreadingModel(), callback: (Value.Error) -> Void) -> Self {
+    public func onFailure(_ context: ExecutionContext = DefaultThreadingModel(), callback: @escaping (Value.Error) -> Void) -> Self {
         self.onComplete(context) { result in
             result.analysis(ifSuccess: { _ in }, ifFailure: callback)
         }
@@ -58,19 +58,19 @@ public extension AsyncType where Value: ResultProtocol {
     /// If this future succeeds, the returned future will complete with the future returned from the given closure.
     ///
     /// The closure is executed on the given context. If no context is given, the behavior is defined by the default threading model (see README.md)
-    public func flatMap<U>(_ context: ExecutionContext, f: (Value.Value) -> Future<U, Value.Error>) -> Future<U, Value.Error> {
+    public func flatMap<U>(_ context: ExecutionContext, f: @escaping (Value.Value) -> Future<U, Value.Error>) -> Future<U, Value.Error> {
         return map(context, f: f).flatten()
     }
     
     /// See `flatMap<U>(context c: ExecutionContext, f: T -> Future<U, E>) -> Future<U, E>`
     /// The given closure is executed according to the default threading model (see README.md)
-    public func flatMap<U>(_ f: (Value.Value) -> Future<U, Value.Error>) -> Future<U, Value.Error> {
+    public func flatMap<U>(_ f: @escaping (Value.Value) -> Future<U, Value.Error>) -> Future<U, Value.Error> {
         return flatMap(DefaultThreadingModel(), f: f)
     }
     
     /// Transforms the given closure returning `Result<U>` to a closure returning `Future<U>` and then calls
     /// `flatMap<U>(context c: ExecutionContext, f: T -> Future<U>) -> Future<U>`
-    public func flatMap<U>(_ context: ExecutionContext, f: (Value.Value) -> Result<U, Value.Error>) -> Future<U, Value.Error> {
+    public func flatMap<U>(_ context: ExecutionContext, f: @escaping (Value.Value) -> Result<U, Value.Error>) -> Future<U, Value.Error> {
         return self.flatMap(context) { value in
             return Future<U, Value.Error>(result: f(value))
         }
@@ -78,20 +78,20 @@ public extension AsyncType where Value: ResultProtocol {
     
     /// See `flatMap<U>(context c: ExecutionContext, f: T -> Result<U, E>) -> Future<U, E>`
     /// The given closure is executed according to the default threading model (see README.md)
-    public func flatMap<U>(_ f: (Value.Value) -> Result<U, Value.Error>) -> Future<U, Value.Error> {
+    public func flatMap<U>(_ f: @escaping (Value.Value) -> Result<U, Value.Error>) -> Future<U, Value.Error> {
         return flatMap(DefaultThreadingModel(), f: f)
     }
     
     /// See `map<U>(context c: ExecutionContext, f: (T) -> U) -> Future<U>`
     /// The given closure is executed according to the default threading model (see README.md)
-    public func map<U>(_ f: (Value.Value) -> U) -> Future<U, Value.Error> {
+    public func map<U>(_ f: @escaping (Value.Value) -> U) -> Future<U, Value.Error> {
         return self.map(DefaultThreadingModel(), f: f)
     }
     
     /// Returns a future that succeeds with the value returned from the given closure when it is invoked with the success value
     /// from this future. If this future fails, the returned future fails with the same error.
     /// The closure is executed on the given context. If no context is given, the behavior is defined by the default threading model (see README.md)
-    public func map<U>(_ context: ExecutionContext, f: (Value.Value) -> U) -> Future<U, Value.Error> {
+    public func map<U>(_ context: ExecutionContext, f: @escaping (Value.Value) -> U) -> Future<U, Value.Error> {
         let res = Future<U, Value.Error>()
         
         self.onComplete(context, callback: { (result: Value) in
@@ -106,7 +106,7 @@ public extension AsyncType where Value: ResultProtocol {
     /// Returns a future that completes with this future if this future succeeds or with the value returned from the given closure
     /// when it is invoked with the error that this future failed with.
     /// The closure is executed on the given context. If no context is given, the behavior is defined by the default threading model (see README.md)
-    public func recover(context c: ExecutionContext = DefaultThreadingModel(), task: (Value.Error) -> Value.Value) -> Future<Value.Value, NoError> {
+    public func recover(context c: ExecutionContext = DefaultThreadingModel(), task: @escaping (Value.Error) -> Value.Value) -> Future<Value.Value, NoError> {
         return self.recoverWith(context: c) { error -> Future<Value.Value, NoError> in
             return Future<Value.Value, NoError>(value: task(error))
         }
@@ -117,7 +117,7 @@ public extension AsyncType where Value: ResultProtocol {
     /// This function should be used in cases where there are two asynchronous operations where the second operation (returned from the given closure)
     /// should only be executed if the first (this future) fails.
     /// The closure is executed on the given context. If no context is given, the behavior is defined by the default threading model (see README.md)
-    public func recoverWith<E1: Error>(context c: ExecutionContext = DefaultThreadingModel(), task: (Value.Error) -> Future<Value.Value, E1>) -> Future<Value.Value, E1> {
+    public func recoverWith<E1: Error>(context c: ExecutionContext = DefaultThreadingModel(), task: @escaping (Value.Error) -> Future<Value.Value, E1>) -> Future<Value.Value, E1> {
         let res = Future<Value.Value, E1>()
         
         self.onComplete(c) { result in
@@ -131,14 +131,14 @@ public extension AsyncType where Value: ResultProtocol {
     
     /// See `mapError<E1>(context c: ExecutionContext, f: E -> E1) -> Future<T, E1>`
     /// The given closure is executed according to the default threading model (see README.md)
-    public func mapError<E1: Error>(_ f: (Value.Error) -> E1) -> Future<Value.Value, E1> {
+    public func mapError<E1: Error>(_ f: @escaping (Value.Error) -> E1) -> Future<Value.Value, E1> {
         return mapError(DefaultThreadingModel(), f: f)
     }
     
     /// Returns a future that fails with the error returned from the given closure when it is invoked with the error
     /// from this future. If this future succeeds, the returned future succeeds with the same value and the closure is not executed.
     /// The closure is executed on the given context.
-    public func mapError<E1: Error>(_ context: ExecutionContext, f: (Value.Error) -> E1) -> Future<Value.Value, E1> {
+    public func mapError<E1: Error>(_ context: ExecutionContext, f: @escaping (Value.Error) -> E1) -> Future<Value.Value, E1> {
         let res = Future<Value.Value, E1>()
         
         self.onComplete(context) { result in
@@ -153,7 +153,7 @@ public extension AsyncType where Value: ResultProtocol {
     /// Adds the given closure as a callback for when this future completes.
     /// The closure is executed on the given context. If no context is given, the behavior is defined by the default threading model (see README.md)
     /// Returns a future that completes with the result from this future but only after executing the given closure
-    public func andThen(context c: ExecutionContext = DefaultThreadingModel(), callback: (Self.Value) -> Void) -> Self {
+    public func andThen(context c: ExecutionContext = DefaultThreadingModel(), callback: @escaping (Self.Value) -> Void) -> Self {
         return Self { complete in
             onComplete(c) { result in
                 callback(result)
@@ -176,7 +176,7 @@ public extension AsyncType where Value: ResultProtocol {
     /// (i.e. the given closure returns `true` when invoked with the success value) or an error with code
     /// `ErrorCode.noSuchElement` if the test failed.
     /// If this future fails, the returned future fails with the same error.
-    public func filter(_ p: (Value.Value) -> Bool) -> Future<Value.Value, BrightFuturesError<Value.Error>> {
+    public func filter(_ p: @escaping (Value.Value) -> Bool) -> Future<Value.Value, BrightFuturesError<Value.Error>> {
         return self.mapError(ImmediateExecutionContext) { error in
             return BrightFuturesError(external: error)
         }.flatMap(ImmediateExecutionContext) { value -> Result<Value.Value, BrightFuturesError<Value.Error>> in

--- a/BrightFutures/AsyncType.swift
+++ b/BrightFutures/AsyncType.swift
@@ -16,11 +16,11 @@ public protocol AsyncType {
     init()
     init(result: Value)
     init(result: Value, delay: DispatchTimeInterval)
-    init<A: AsyncType where A.Value == Value>(other: A)
-    init(resolver: @noescape (result: (Value) -> Void) -> Void)
+    init<A: AsyncType>(other: A) where A.Value == Value
+    init(resolver: (_ result: @escaping (Value) -> Void) -> Void)
     
     @discardableResult
-    func onComplete(_ context: ExecutionContext, callback: (Value) -> Void) -> Self
+    func onComplete(_ context: ExecutionContext, callback: @escaping (Value) -> Void) -> Self
 }
 
 public extension AsyncType {
@@ -31,12 +31,12 @@ public extension AsyncType {
     
     /// Blocks the current thread until the future is completed and then returns the result
     public func forced() -> Value {
-        return forced(timeout: DispatchTime.distantFuture)!
+        return forced(DispatchTime.distantFuture)!
     }
     
     /// Blocks the current thread until the future is completed, but no longer than the given timeout
     /// If the future did not complete before the timeout, `nil` is returned, otherwise the result of the future is returned
-    public func forced(timeout: DispatchTime) -> Value? {
+    public func forced(_ timeout: DispatchTime) -> Value? {
         if let result = result {
             return result
         }

--- a/BrightFutures/Dispatch+BrightFutures.swift
+++ b/BrightFutures/Dispatch+BrightFutures.swift
@@ -16,7 +16,7 @@ public extension DispatchQueue {
         }
     }
     
-    public func asyncValue<T>(execute: () -> T) -> Future<T, NoError> {
+    public func asyncValue<T>(_ execute: @escaping () -> T) -> Future<T, NoError> {
         return Future { completion in
             async {
                 completion(.success(execute()))
@@ -24,7 +24,7 @@ public extension DispatchQueue {
         }
     }
     
-    public func asyncResult<T, E: Error>(execute: () -> Result<T, E>) -> Future<T, E> {
+    public func asyncResult<T, E: Error>(_ execute: @escaping () -> Result<T, E>) -> Future<T, E> {
         return Future { completion in
             async {
                 completion(execute())
@@ -32,7 +32,7 @@ public extension DispatchQueue {
         }
     }
     
-    public func asyncValueAfter<T>(deadline: DispatchTime, execute: () -> T) -> Future<T, NoError> {
+    public func asyncValueAfter<T>(_ deadline: DispatchTime, execute: @escaping () -> T) -> Future<T, NoError> {
         return Future { completion in
             asyncAfter(deadline: deadline) {
                 completion(.success(execute()))

--- a/BrightFutures/ExecutionContext.swift
+++ b/BrightFutures/ExecutionContext.swift
@@ -24,7 +24,7 @@ import Foundation
 
 /// The context in which something can be executed
 /// By default, an execution context can be assumed to be asynchronous unless stated otherwise
-public typealias ExecutionContext = (() -> Void) -> Void
+public typealias ExecutionContext = (@escaping () -> Void) -> Void
 
 /// Immediately executes the given task. No threading, no semaphores.
 public let ImmediateExecutionContext: ExecutionContext = { task in

--- a/BrightFutures/InvalidationToken.swift
+++ b/BrightFutures/InvalidationToken.swift
@@ -48,20 +48,20 @@ public protocol ManualInvalidationTokenType : InvalidationTokenType {
 }
 
 /// A default invalidation token implementation
-public class InvalidationToken : ManualInvalidationTokenType {
+open class InvalidationToken : ManualInvalidationTokenType {
    
-    public let future = Future<NoValue, BrightFuturesError<NoError>>()
+    open let future = Future<NoValue, BrightFuturesError<NoError>>()
     
     /// Creates a new valid token
     public init() { }
     
     /// Indicates if the token is invalid
-    public var isInvalid: Bool {
+    open var isInvalid: Bool {
         return future.isCompleted
     }
     
     /// Invalidates the token
-    public func invalidate() {
+    open func invalidate() {
         future.failure(.invalidationTokenInvalidated)
     }
 }

--- a/BrightFutures/MutableAsyncType.swift
+++ b/BrightFutures/MutableAsyncType.swift
@@ -28,7 +28,7 @@ extension MutableAsyncType {
         }
     }
     
-    func completeWith<A: AsyncType where A.Value == Value>(_ other: A) {
+    func completeWith<A: AsyncType>(_ other: A) where A.Value == Value {
         other.onComplete(ImmediateExecutionContext, callback: self.complete)
     }
 }

--- a/BrightFutures/Promise.swift
+++ b/BrightFutures/Promise.swift
@@ -29,10 +29,10 @@ import Result
 /// when the asynchronous operation is completed. Completing a 
 /// promise is thread safe and is typically performed from the 
 /// (background) thread where the operation itself is also performed.
-public class Promise<T, E: Error> {
+open class Promise<T, E: Error> {
 
     /// The future that will complete through this promise
-    public let future: Future<T, E>
+    open let future: Future<T, E>
     
     /// Creates a new promise with a pending future
     public init() {
@@ -40,46 +40,46 @@ public class Promise<T, E: Error> {
     }
     
     /// Completes the promise's future with the given future
-    public func completeWith(_ other: Future<T, E>) {
+    open func completeWith(_ other: Future<T, E>) {
         future.completeWith(other)
     }
     
     /// Completes the promise's future with the given success value
     /// See `Future.success(value: T)`
-    public func success(_ value: T) {
+    open func success(_ value: T) {
         future.success(value)
     }
     
     /// Attempts to complete the promise's future with the given success value
     /// See `future.trySuccess(value: T)`
     @discardableResult
-    public func trySuccess(_ value: T) -> Bool {
+    open func trySuccess(_ value: T) -> Bool {
         return future.trySuccess(value)
     }
     
     /// Completes the promise's future with the given error
     /// See `future.failure(error: E)`
-    public func failure(_ error: E) {
+    open func failure(_ error: E) {
         future.failure(error)
     }
 
     /// Attempts to complete the promise's future with the given error
     /// See `future.tryFailure(error: E)`
     @discardableResult
-    public func tryFailure(_ error: E) -> Bool {
+    open func tryFailure(_ error: E) -> Bool {
         return future.tryFailure(error)
     }
 
     /// Completes the promise's future with the given result
     /// See `future.complete(result: Result<T, E>)`
-    public func complete(_ result: Result<T, E>) {
+    open func complete(_ result: Result<T, E>) {
         future.complete(result)
     }
     
     /// Attempts to complete the promise's future with the given result
     /// See `future.tryComplete(result: Result<T, E>)`
     @discardableResult
-    public func tryComplete(_ result: Result<T,E>) -> Bool {
+    open func tryComplete(_ result: Result<T,E>) -> Bool {
         return future.tryComplete(result)
     }
     

--- a/BrightFutures/Result+BrightFutures.swift
+++ b/BrightFutures/Result+BrightFutures.swift
@@ -15,7 +15,7 @@ extension ResultProtocol {
     /// if the first operation result is a .success
     /// If a regular `map` was used, the result would be `Result<Future<U>>`.
     /// The implementation of this function uses `map`, but then flattens the result before returning it.
-    public func flatMap<U>(_ f: @noescape (Value) -> Future<U, Error>) -> Future<U, Error> {
+    public func flatMap<U>(_ f: (Value) -> Future<U, Error>) -> Future<U, Error> {
         return analysis(ifSuccess: {
             return f($0)
         }, ifFailure: {

--- a/BrightFutures/SequenceType+BrightFutures.swift
+++ b/BrightFutures/SequenceType+BrightFutures.swift
@@ -26,7 +26,7 @@ import Result
 extension Sequence {
     /// Turns a sequence of T's into an array of `Future<U>`'s by calling the given closure for each element in the sequence.
     /// If no context is provided, the given closure is executed on `Queue.global`
-    public func traverse<U, E, A: AsyncType where A.Value: ResultProtocol, A.Value.Value == U, A.Value.Error == E>(_ context: ExecutionContext = DispatchQueue.global().context, f: (Iterator.Element) -> A) -> Future<[U], E> {
+    public func traverse<U, E, A: AsyncType>(_ context: ExecutionContext = DispatchQueue.global().context, f: (Iterator.Element) -> A) -> Future<[U], E> where A.Value: ResultProtocol, A.Value.Value == U, A.Value.Error == E {
         return map(f).fold(context, zero: [U]()) { (list: [U], elem: U) -> [U] in
             return list + [elem]
         }
@@ -55,13 +55,13 @@ extension Sequence where Iterator.Element: AsyncType, Iterator.Element.Value: Re
     /// on `Queue.global`.
     /// (The Swift compiler does not allow a context parameter with a default value
     /// so we define some functions twice)
-    public func fold<R>(_ zero: R, f: (R, Iterator.Element.Value.Value) -> R) -> Future<R, Iterator.Element.Value.Error> {
+    public func fold<R>(_ zero: R, f: @escaping (R, Iterator.Element.Value.Value) -> R) -> Future<R, Iterator.Element.Value.Error> {
         return fold(DispatchQueue.global().context, zero: zero, f: f)
     }
     
     /// Performs the fold operation over a sequence of futures. The folding is performed
     /// in the given context.
-    public func fold<R>(_ context: ExecutionContext, zero: R, f: (R, Iterator.Element.Value.Value) -> R) -> Future<R, Iterator.Element.Value.Error> {
+    public func fold<R>(_ context: ExecutionContext, zero: R, f: @escaping (R, Iterator.Element.Value.Value) -> R) -> Future<R, Iterator.Element.Value.Error> {
         return reduce(Future<R, Iterator.Element.Value.Error>(value: zero)) { zero, elem in
             return zero.flatMap(MaxStackDepthExecutionContext) { zeroVal in
                 elem.map(context) { elemVal in
@@ -81,7 +81,7 @@ extension Sequence where Iterator.Element: AsyncType, Iterator.Element.Value: Re
     }
     
     /// See `find<S: SequenceType, T where S.Iterator.Element == Future<T>>(seq: S, context c: ExecutionContext, p: T -> Bool) -> Future<T>`
-    public func find(_ p: (Iterator.Element.Value.Value) -> Bool) -> Future<Iterator.Element.Value.Value, BrightFuturesError<Iterator.Element.Value.Error>> {
+    public func find(_ p: @escaping (Iterator.Element.Value.Value) -> Bool) -> Future<Iterator.Element.Value.Value, BrightFuturesError<Iterator.Element.Value.Error>> {
         return find(DispatchQueue.global().context, p: p)
     }
     
@@ -90,7 +90,7 @@ extension Sequence where Iterator.Element: AsyncType, Iterator.Element.Value: Re
     /// If any of the futures in the given sequence fail, the returned future fails with the
     /// error of the first failed future in the sequence.
     /// If no futures in the sequence pass the test, a future with an error with NoSuchElement is returned.
-    public func find(_ context: ExecutionContext, p: (Iterator.Element.Value.Value) -> Bool) -> Future<Iterator.Element.Value.Value, BrightFuturesError<Iterator.Element.Value.Error>> {
+    public func find(_ context: ExecutionContext, p: @escaping (Iterator.Element.Value.Value) -> Bool) -> Future<Iterator.Element.Value.Value, BrightFuturesError<Iterator.Element.Value.Error>> {
         return sequence().mapError(ImmediateExecutionContext) { error in
             return BrightFuturesError(external: error)
         }.flatMap(context) { val -> Result<Iterator.Element.Value.Value, BrightFuturesError<Iterator.Element.Value.Error>> in

--- a/BrightFuturesTests/BrightFuturesTests.swift
+++ b/BrightFuturesTests/BrightFuturesTests.swift
@@ -253,11 +253,11 @@ extension BrightFuturesTests {
             }
         }
         
-        let f = materialize { testCall(0, completionHandler: $0) }
+        let f = BrightFutures.materialize { testCall(0, completionHandler: $0) }
         XCTAssert(f.error == nil)
         
-        let f2 = materialize { testCall(2, completionHandler: $0) }
-        XCTAssert(f2.error == TestError.justAnError)
+        let f2 = BrightFutures.materialize { testCall(2, completionHandler: $0) }
+        XCTAssert(f2.error! == TestError.justAnError)
     }
 }
 
@@ -572,9 +572,9 @@ extension BrightFuturesTests {
             Thread.sleep(forTimeInterval: 0.5)
         }
         
-        XCTAssert(f.forced(timeout: 100.milliseconds.fromNow) == nil)
+        XCTAssert(f.forced(100.milliseconds.fromNow) == nil)
         
-        XCTAssert(f.forced(timeout: 500.milliseconds.fromNow) != nil)
+        XCTAssert(f.forced(500.milliseconds.fromNow) != nil)
     }
     
     func testForcingCompletedFuture() {
@@ -1165,6 +1165,6 @@ func fibonacciFuture(_ n: Int) -> Future<Int, NoError> {
     return Future<Int, NoError>(value: fibonacci(n))
 }
 
-func getMutablePointer (_ object: AnyObject) -> UnsafeMutablePointer<Void> {
-    return UnsafeMutablePointer<Void>(bitPattern: Int(UInt(ObjectIdentifier(object))))!
+func getMutablePointer (_ object: AnyObject) -> UnsafeMutableRawPointer {
+    return UnsafeMutableRawPointer(bitPattern: Int(UInt(bitPattern: ObjectIdentifier(object))))!
 }

--- a/BrightFuturesTests/QueueTests.swift
+++ b/BrightFuturesTests/QueueTests.swift
@@ -120,7 +120,7 @@ class QueueTests: XCTestCase {
     func testAfterFuture() {
         // unfortunately, the compiler is not able to figure out that we want the
         // future-returning async method
-        let f: Future<String, NoError> = DispatchQueue.global().asyncValueAfter(deadline: 1.second.fromNow) {
+        let f: Future<String, NoError> = DispatchQueue.global().asyncValueAfter(1.second.fromNow) {
             return "fibonacci"
         }
         

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "antitypical/Result" ~> 3.0
+github "antitypical/Result" "master"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "antitypical/Result" "3.0.0-alpha.2"
+github "antitypical/Result" "d78cac38657de99d85f8f1770b290d039721ef27"


### PR DESCRIPTION
`public` methods have been converted to `open` as per the Xcode migrator
to maintain external compatibility however moving to the new `public`
access level may be ultimately desirable.