### PR TITLE
Debug functionality to AsyncType

### DIFF
--- a/BrightFutures.xcodeproj/project.pbxproj
+++ b/BrightFutures.xcodeproj/project.pbxproj
@@ -11,6 +11,9 @@
 		CE1FE85C1D951F1400B2BB9F /* AsyncType+Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1FE85A1D951F1400B2BB9F /* AsyncType+Debug.swift */; };
 		CE1FE85D1D951F1400B2BB9F /* AsyncType+Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1FE85A1D951F1400B2BB9F /* AsyncType+Debug.swift */; };
 		CE1FE85E1D951F1400B2BB9F /* AsyncType+Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1FE85A1D951F1400B2BB9F /* AsyncType+Debug.swift */; };
+		CE1FE8601D952C3D00B2BB9F /* FutureDebugTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1FE85F1D952C3D00B2BB9F /* FutureDebugTests.swift */; };
+		CE1FE8611D952C3D00B2BB9F /* FutureDebugTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1FE85F1D952C3D00B2BB9F /* FutureDebugTests.swift */; };
+		CE1FE8621D952C3D00B2BB9F /* FutureDebugTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1FE85F1D952C3D00B2BB9F /* FutureDebugTests.swift */; };
 		E9039ADD1A45DF8D000DD6F1 /* ResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9039ADC1A45DF8D000DD6F1 /* ResultTests.swift */; };
 		E9319EA41A397D2C00A0604A /* QueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9319EA31A397D2C00A0604A /* QueueTests.swift */; };
 		E943D28D1BAC0FFD00E9EFB3 /* NSOperationQueue+BrightFutures.swift in Sources */ = {isa = PBXBuildFile; fileRef = E943D28C1BAC0FFD00E9EFB3 /* NSOperationQueue+BrightFutures.swift */; };
@@ -155,6 +158,7 @@
 
 /* Begin PBXFileReference section */
 		CE1FE85A1D951F1400B2BB9F /* AsyncType+Debug.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AsyncType+Debug.swift"; sourceTree = "<group>"; };
+		CE1FE85F1D952C3D00B2BB9F /* FutureDebugTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FutureDebugTests.swift; sourceTree = "<group>"; };
 		E9039ADC1A45DF8D000DD6F1 /* ResultTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultTests.swift; sourceTree = "<group>"; };
 		E9319EA31A397D2C00A0604A /* QueueTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueueTests.swift; sourceTree = "<group>"; };
 		E943D28C1BAC0FFD00E9EFB3 /* NSOperationQueue+BrightFutures.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSOperationQueue+BrightFutures.swift"; sourceTree = "<group>"; };
@@ -363,6 +367,7 @@
 				E9E422C51B1FA28F0000558F /* ErrorsTests.swift */,
 				E9E422C81B1FA5300000558F /* ExecutionContextTests.swift */,
 				E99397C31BAD49EC00A0B077 /* NSOperationQueueTests.swift */,
+				CE1FE85F1D952C3D00B2BB9F /* FutureDebugTests.swift */,
 				E9DF0825194470060083F7F2 /* Supporting Files */,
 			);
 			path = BrightFuturesTests;
@@ -667,6 +672,7 @@
 				E98647CB1BF3288D00B6BEEE /* NSOperationQueueTests.swift in Sources */,
 				E98647C91BF3288D00B6BEEE /* ExecutionContextTests.swift in Sources */,
 				E98647C51BF3288D00B6BEEE /* QueueTests.swift in Sources */,
+				CE1FE8621D952C3D00B2BB9F /* FutureDebugTests.swift in Sources */,
 				E98647C61BF3288D00B6BEEE /* ResultTests.swift in Sources */,
 				E98647C41BF3288D00B6BEEE /* PromiseTests.swift in Sources */,
 			);
@@ -728,6 +734,7 @@
 				E9D45B241AF00676000F6CA7 /* InvalidationTokenTests.swift in Sources */,
 				E9D45B211AF00676000F6CA7 /* BrightFuturesTests.swift in Sources */,
 				E9D45B221AF00676000F6CA7 /* QueueTests.swift in Sources */,
+				CE1FE8611D952C3D00B2BB9F /* FutureDebugTests.swift in Sources */,
 				E9E422CA1B1FA5300000558F /* ExecutionContextTests.swift in Sources */,
 				E9D45B231AF00676000F6CA7 /* ResultTests.swift in Sources */,
 			);
@@ -766,6 +773,7 @@
 				E9039ADD1A45DF8D000DD6F1 /* ResultTests.swift in Sources */,
 				E9D923AE1A6CE69B00CADD9F /* InvalidationTokenTests.swift in Sources */,
 				E9DF0828194470060083F7F2 /* BrightFuturesTests.swift in Sources */,
+				CE1FE8601D952C3D00B2BB9F /* FutureDebugTests.swift in Sources */,
 				E9E422C91B1FA5300000558F /* ExecutionContextTests.swift in Sources */,
 				E9319EA41A397D2C00A0604A /* QueueTests.swift in Sources */,
 			);

--- a/BrightFutures.xcodeproj/project.pbxproj
+++ b/BrightFutures.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		CE1FE85B1D951F1400B2BB9F /* AsyncType+Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1FE85A1D951F1400B2BB9F /* AsyncType+Debug.swift */; };
+		CE1FE85C1D951F1400B2BB9F /* AsyncType+Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1FE85A1D951F1400B2BB9F /* AsyncType+Debug.swift */; };
+		CE1FE85D1D951F1400B2BB9F /* AsyncType+Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1FE85A1D951F1400B2BB9F /* AsyncType+Debug.swift */; };
+		CE1FE85E1D951F1400B2BB9F /* AsyncType+Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1FE85A1D951F1400B2BB9F /* AsyncType+Debug.swift */; };
 		E9039ADD1A45DF8D000DD6F1 /* ResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9039ADC1A45DF8D000DD6F1 /* ResultTests.swift */; };
 		E9319EA41A397D2C00A0604A /* QueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9319EA31A397D2C00A0604A /* QueueTests.swift */; };
 		E943D28D1BAC0FFD00E9EFB3 /* NSOperationQueue+BrightFutures.swift in Sources */ = {isa = PBXBuildFile; fileRef = E943D28C1BAC0FFD00E9EFB3 /* NSOperationQueue+BrightFutures.swift */; };
@@ -150,6 +154,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		CE1FE85A1D951F1400B2BB9F /* AsyncType+Debug.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AsyncType+Debug.swift"; sourceTree = "<group>"; };
 		E9039ADC1A45DF8D000DD6F1 /* ResultTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultTests.swift; sourceTree = "<group>"; };
 		E9319EA31A397D2C00A0604A /* QueueTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueueTests.swift; sourceTree = "<group>"; };
 		E943D28C1BAC0FFD00E9EFB3 /* NSOperationQueue+BrightFutures.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSOperationQueue+BrightFutures.swift"; sourceTree = "<group>"; };
@@ -326,6 +331,7 @@
 				E9DD4EEE1B4ED51A0070C2AF /* AsyncType.swift */,
 				E9DD4EF01B4ED6850070C2AF /* Async.swift */,
 				E992A95E1B501AC800A9FC4F /* AsyncType+ResultType.swift */,
+				CE1FE85A1D951F1400B2BB9F /* AsyncType+Debug.swift */,
 				E9CA7B401B555DB200102F87 /* MutableAsyncType.swift */,
 				E9B094671B5FE086003AC209 /* MutableAsyncType+ResultType.swift */,
 				E9F69B9A1B93347200713A91 /* Result+BrightFutures.swift */,
@@ -634,6 +640,7 @@
 			files = (
 				E98647C21BF3288400B6BEEE /* NSOperationQueue+BrightFutures.swift in Sources */,
 				E98647BD1BF3288400B6BEEE /* AsyncType+ResultType.swift in Sources */,
+				CE1FE85E1D951F1400B2BB9F /* AsyncType+Debug.swift in Sources */,
 				E9E892601D5F24AE00C1859D /* Dispatch+BrightFutures.swift in Sources */,
 				E98647B61BF3288400B6BEEE /* Future.swift in Sources */,
 				E98647BB1BF3288400B6BEEE /* AsyncType.swift in Sources */,
@@ -671,6 +678,7 @@
 			files = (
 				E943D28F1BAC0FFD00E9EFB3 /* NSOperationQueue+BrightFutures.swift in Sources */,
 				E9877CB51B826AA5009DB030 /* Future.swift in Sources */,
+				CE1FE85D1D951F1400B2BB9F /* AsyncType+Debug.swift in Sources */,
 				E9E8925F1D5F24AE00C1859D /* Dispatch+BrightFutures.swift in Sources */,
 				E9877CB41B826AA5009DB030 /* ExecutionContext.swift in Sources */,
 				E9F69B9D1B93347200713A91 /* Result+BrightFutures.swift in Sources */,
@@ -693,6 +701,7 @@
 			files = (
 				E9F496F01B052F1400F82839 /* Errors.swift in Sources */,
 				E943D28E1BAC0FFD00E9EFB3 /* NSOperationQueue+BrightFutures.swift in Sources */,
+				CE1FE85C1D951F1400B2BB9F /* AsyncType+Debug.swift in Sources */,
 				E9E8925E1D5F24AE00C1859D /* Dispatch+BrightFutures.swift in Sources */,
 				E9D45B1B1AF00668000F6CA7 /* Future.swift in Sources */,
 				E9F69B9C1B93347200713A91 /* Result+BrightFutures.swift in Sources */,
@@ -730,6 +739,7 @@
 			files = (
 				E9F496EF1B052F1400F82839 /* Errors.swift in Sources */,
 				E943D28D1BAC0FFD00E9EFB3 /* NSOperationQueue+BrightFutures.swift in Sources */,
+				CE1FE85B1D951F1400B2BB9F /* AsyncType+Debug.swift in Sources */,
 				E9E8925D1D5F24AE00C1859D /* Dispatch+BrightFutures.swift in Sources */,
 				E979E5F41975B1AA007FE914 /* SequenceType+BrightFutures.swift in Sources */,
 				E95507001B525D0B00359F73 /* Async.swift in Sources */,

--- a/BrightFutures/AsyncType+Debug.swift
+++ b/BrightFutures/AsyncType+Debug.swift
@@ -24,6 +24,21 @@ public extension AsyncType where Value: ResultProtocol {
             logger.log(message: messageBlock(result))
         })
     }
+    
+    public func debug(_ identifer: String? = nil, logger: LoggerType = Logger(), file: String = #file, line: UInt = #line, function: String = #function, context c: @escaping ExecutionContext = DefaultThreadingModel()) -> Self {
+        return debug(logger: logger, context: c, messageBlock: { result -> String in
+            let messageBody: String
+            let resultString = result.analysis(ifSuccess: { _ in "succeeded" } , ifFailure: { _ in "failed" })
+            
+            if let identifer = identifer {
+                messageBody = "Future \(identifer)"
+            } else {
+                messageBody = "\(file.lastPathComponent) at line \(line), func: \(function) - future"
+            }
+            
+            return "\(messageBody) \(resultString)"
+        })
+    }
 }
 
 extension String {

--- a/BrightFutures/AsyncType+Debug.swift
+++ b/BrightFutures/AsyncType+Debug.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2016 Thomas Visser. All rights reserved.
 //
 
+import Foundation
 import Result
 
 public protocol LoggerType {
@@ -33,16 +34,11 @@ public extension AsyncType where Value: ResultProtocol {
             if let identifer = identifer {
                 messageBody = "Future \(identifer)"
             } else {
-                messageBody = "\(file.lastPathComponent) at line \(line), func: \(function) - future"
+                let fileName = (file as NSString).lastPathComponent
+                messageBody = "\(fileName) at line \(line), func: \(function) - future"
             }
             
             return "\(messageBody) \(resultString)"
         })
-    }
-}
-
-extension String {
-    var lastPathComponent: String {
-        return characters.split(separator: "/").lazy.last.flatMap({ String($0) }) ?? self
     }
 }

--- a/BrightFutures/AsyncType+Debug.swift
+++ b/BrightFutures/AsyncType+Debug.swift
@@ -6,4 +6,9 @@
 //  Copyright © 2016 Thomas Visser. All rights reserved.
 //
 
-import Foundation
+import Result
+
+public protocol LoggerType {
+    func log(message: String)
+}
+

--- a/BrightFutures/AsyncType+Debug.swift
+++ b/BrightFutures/AsyncType+Debug.swift
@@ -36,15 +36,10 @@ fileprivate struct Logger: LoggerType {
 }
 
 public extension AsyncType {
-    public func debug(logger: LoggerType = Logger(), context c: @escaping ExecutionContext = DefaultThreadingModel(), messageBlock: @escaping (Self.Value) -> String) -> Self {
-        return andThen(context: c, callback: { result in
-            logger.log(message: messageBlock(result))
-        })
-    }
-    
     public func debug(_ identifier: String? = nil, logger: LoggerType = Logger(), file: String = #file, line: UInt = #line, function: String = #function, context c: @escaping ExecutionContext = DefaultThreadingModel()) -> Self {
-        return debug(logger: logger, context: c, messageBlock: { result -> String in
-            return logger.message(for: result, with: identifier, file: file, line: line, function: function)
+        return andThen(context: c, callback: { result in
+            let message = logger.message(for: result, with: identifier, file: file, line: line, function: function)
+            logger.log(message: message)
         })
     }
 }

--- a/BrightFutures/AsyncType+Debug.swift
+++ b/BrightFutures/AsyncType+Debug.swift
@@ -25,3 +25,9 @@ public extension AsyncType where Value: ResultProtocol {
         })
     }
 }
+
+extension String {
+    var lastPathComponent: String {
+        return characters.split(separator: "/").lazy.last.flatMap({ String($0) }) ?? self
+    }
+}

--- a/BrightFutures/AsyncType+Debug.swift
+++ b/BrightFutures/AsyncType+Debug.swift
@@ -12,3 +12,8 @@ public protocol LoggerType {
     func log(message: String)
 }
 
+struct Logger: LoggerType {
+    func log(message: String) {
+        print(message)
+    }
+}

--- a/BrightFutures/AsyncType+Debug.swift
+++ b/BrightFutures/AsyncType+Debug.swift
@@ -17,3 +17,11 @@ struct Logger: LoggerType {
         print(message)
     }
 }
+
+public extension AsyncType where Value: ResultProtocol {
+    public func debug(logger: LoggerType = Logger(), context c: @escaping ExecutionContext = DefaultThreadingModel(), messageBlock: @escaping (Self.Value) -> String) -> Self {
+        return andThen(context: c, callback: { result in
+            logger.log(message: messageBlock(result))
+        })
+    }
+}

--- a/BrightFutures/AsyncType+Debug.swift
+++ b/BrightFutures/AsyncType+Debug.swift
@@ -1,0 +1,9 @@
+//
+//  AsyncType+Debug.swift
+//  BrightFutures
+//
+//  Created by Oleksii on 23/09/2016.
+//  Copyright © 2016 Thomas Visser. All rights reserved.
+//
+
+import Foundation

--- a/BrightFutures/AsyncType+Debug.swift
+++ b/BrightFutures/AsyncType+Debug.swift
@@ -12,7 +12,7 @@ public protocol LoggerType {
     func log(message: String)
 }
 
-struct Logger: LoggerType {
+fileprivate struct Logger: LoggerType {
     func log(message: String) {
         print(message)
     }

--- a/BrightFutures/AsyncType+ResultType.swift
+++ b/BrightFutures/AsyncType+ResultType.swift
@@ -150,18 +150,6 @@ public extension AsyncType where Value: ResultProtocol {
         return res
     }
     
-    /// Adds the given closure as a callback for when this future completes.
-    /// The closure is executed on the given context. If no context is given, the behavior is defined by the default threading model (see README.md)
-    /// Returns a future that completes with the result from this future but only after executing the given closure
-    public func andThen(context c: @escaping ExecutionContext = DefaultThreadingModel(), callback: @escaping (Self.Value) -> Void) -> Self {
-        return Self { complete in
-            onComplete(c) { result in
-                callback(result)
-                complete(result)
-            }
-        }
-    }
-    
     /// Returns a future that succeeds with a tuple consisting of the success value of this future and the success value of the given future
     /// If either of the two futures fail, the returned future fails with the failure of this future or that future (in this order)
     public func zip<U>(_ that: Future<U, Value.Error>) -> Future<(Value.Value,U), Value.Error> {

--- a/BrightFutures/AsyncType.swift
+++ b/BrightFutures/AsyncType.swift
@@ -78,6 +78,18 @@ public extension AsyncType {
             }
         }
     }
+    
+    /// Adds the given closure as a callback for when this future completes.
+    /// The closure is executed on the given context. If no context is given, the behavior is defined by the default threading model (see README.md)
+    /// Returns a future that completes with the result from this future but only after executing the given closure
+    public func andThen(context c: @escaping ExecutionContext = DefaultThreadingModel(), callback: @escaping (Self.Value) -> Void) -> Self {
+        return Self { complete in
+            onComplete(c) { result in
+                callback(result)
+                complete(result)
+            }
+        }
+    }
 }
 
 public extension AsyncType where Value: AsyncType {

--- a/BrightFuturesTests/FutureDebugTests.swift
+++ b/BrightFuturesTests/FutureDebugTests.swift
@@ -9,6 +9,14 @@
 import XCTest
 @testable import BrightFutures
 
+class TestLogger: LoggerType {
+    var lastLoggedMessage: String?
+    
+    func log(message: String) {
+        lastLoggedMessage = message
+    }
+}
+
 class FutureDebugTests: XCTestCase {
     
     func testStringLastPathComponent() {

--- a/BrightFuturesTests/FutureDebugTests.swift
+++ b/BrightFuturesTests/FutureDebugTests.swift
@@ -47,6 +47,20 @@ class FutureDebugTests: XCTestCase {
         self.waitForExpectations(timeout: 2, handler: nil)
     }
     
+    func testDebugFutureFailure() {
+        let logger = TestLogger()
+        let f = Future<Void, NSError>(error: error).debug(logger: logger, file: file, line: line, function: function)
+        let debugExpectation = self.expectation(description: "debugLogged")
+        let expectedMessage = "\(file.lastPathComponent) at line \(line), func: \(function) - future failed"
+        
+        f.onFailure { _ in
+            XCTAssertEqual(logger.lastLoggedMessage, expectedMessage)
+            debugExpectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 2, handler: nil)
+    }
+    
     func testDebugFutureSuccessWithIdentifier() {
         let logger = TestLogger()
         

--- a/BrightFuturesTests/FutureDebugTests.swift
+++ b/BrightFuturesTests/FutureDebugTests.swift
@@ -8,7 +8,7 @@
 
 import XCTest
 import Result
-@testable import BrightFutures
+import BrightFutures
 
 class TestLogger: LoggerType {
     var lastLoggedMessage: String?
@@ -22,21 +22,14 @@ class FutureDebugTests: XCTestCase {
     let testIdentifier = "testFutureIdentifier"
     let error = NSError(domain: "test", code: 0, userInfo: nil)
     let file = #file
+    let fileName = (#file as NSString).lastPathComponent
     let line: UInt = #line
     let function = #function
-    
-    func testStringLastPathComponent() {
-        XCTAssertEqual("/tmp/scratch.tiff".lastPathComponent, "scratch.tiff")
-        XCTAssertEqual("/tmp/scratch".lastPathComponent, "scratch")
-        XCTAssertEqual("/tmp/".lastPathComponent, "tmp")
-        XCTAssertEqual("scratch///".lastPathComponent, "scratch")
-        XCTAssertEqual("/".lastPathComponent, "/")
-    }
     
     func testDebugFutureSuccess() {
         let logger = TestLogger()
         let f = Future<Void, NoError>(value: ()).debug(logger: logger, file: file, line: line, function: function)
-        let expectedMessage = "\(file.lastPathComponent) at line \(line), func: \(function) - future succeeded"
+        let expectedMessage = "\(fileName) at line \(line), func: \(function) - future succeeded"
         let debugExpectation = self.expectation(description: "debugLogged")
         
         f.onSuccess {
@@ -51,7 +44,7 @@ class FutureDebugTests: XCTestCase {
         let logger = TestLogger()
         let f = Future<Void, NSError>(error: error).debug(logger: logger, file: file, line: line, function: function)
         let debugExpectation = self.expectation(description: "debugLogged")
-        let expectedMessage = "\(file.lastPathComponent) at line \(line), func: \(function) - future failed"
+        let expectedMessage = "\(fileName) at line \(line), func: \(function) - future failed"
         
         f.onFailure { _ in
             XCTAssertEqual(logger.lastLoggedMessage, expectedMessage)

--- a/BrightFuturesTests/FutureDebugTests.swift
+++ b/BrightFuturesTests/FutureDebugTests.swift
@@ -26,10 +26,10 @@ class FutureDebugTests: XCTestCase {
     let line: UInt = #line
     let function = #function
     
-    func testDebugFutureSuccess() {
+    func testDebugFuture() {
         let logger = TestLogger()
         let f = Future<Void, NoError>(value: ()).debug(logger: logger, file: file, line: line, function: function)
-        let expectedMessage = "\(fileName) at line \(line), func: \(function) - future succeeded"
+        let expectedMessage = "\(fileName) at line \(line), func: \(function) - future completed"
         let debugExpectation = self.expectation(description: "debugLogged")
         
         f.onSuccess {
@@ -40,41 +40,14 @@ class FutureDebugTests: XCTestCase {
         self.waitForExpectations(timeout: 2, handler: nil)
     }
     
-    func testDebugFutureFailure() {
-        let logger = TestLogger()
-        let f = Future<Void, NSError>(error: error).debug(logger: logger, file: file, line: line, function: function)
-        let debugExpectation = self.expectation(description: "debugLogged")
-        let expectedMessage = "\(fileName) at line \(line), func: \(function) - future failed"
-        
-        f.onFailure { _ in
-            XCTAssertEqual(logger.lastLoggedMessage, expectedMessage)
-            debugExpectation.fulfill()
-        }
-        
-        self.waitForExpectations(timeout: 2, handler: nil)
-    }
-    
-    func testDebugFutureSuccessWithIdentifier() {
+    func testDebugFutureWithIdentifier() {
         let logger = TestLogger()
         
         let f = Future<Void, NoError>(value: ()).debug(testIdentifier, logger: logger)
         let debugExpectation = self.expectation(description: "debugLogged")
         
         f.onSuccess {
-            XCTAssertEqual(logger.lastLoggedMessage, "Future \(self.testIdentifier) succeeded")
-            debugExpectation.fulfill()
-        }
-        
-        self.waitForExpectations(timeout: 2, handler: nil)
-    }
-    
-    func testDebugFutureFailureWithIdentifier() {
-        let logger = TestLogger()
-        let f = Future<Void, NSError>(error: error).debug(testIdentifier, logger: logger)
-        let debugExpectation = self.expectation(description: "debugLogged")
-        
-        f.onFailure { _ in
-            XCTAssertEqual(logger.lastLoggedMessage, "Future \(self.testIdentifier) failed")
+            XCTAssertEqual(logger.lastLoggedMessage, "Future \(self.testIdentifier) completed")
             debugExpectation.fulfill()
         }
         

--- a/BrightFuturesTests/FutureDebugTests.swift
+++ b/BrightFuturesTests/FutureDebugTests.swift
@@ -21,6 +21,9 @@ class TestLogger: LoggerType {
 class FutureDebugTests: XCTestCase {
     let testIdentifier = "testFutureIdentifier"
     let error = NSError(domain: "test", code: 0, userInfo: nil)
+    let file = #file
+    let line: UInt = #line
+    let function = #function
     
     func testStringLastPathComponent() {
         XCTAssertEqual("/tmp/scratch.tiff".lastPathComponent, "scratch.tiff")
@@ -28,6 +31,20 @@ class FutureDebugTests: XCTestCase {
         XCTAssertEqual("/tmp/".lastPathComponent, "tmp")
         XCTAssertEqual("scratch///".lastPathComponent, "scratch")
         XCTAssertEqual("/".lastPathComponent, "/")
+    }
+    
+    func testDebugFutureSuccess() {
+        let logger = TestLogger()
+        let f = Future<Void, NoError>(value: ()).debug(logger: logger, file: file, line: line, function: function)
+        let expectedMessage = "\(file.lastPathComponent) at line \(line), func: \(function) - future succeeded"
+        let debugExpectation = self.expectation(description: "debugLogged")
+        
+        f.onSuccess {
+            XCTAssertEqual(logger.lastLoggedMessage, expectedMessage)
+            debugExpectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 2, handler: nil)
     }
     
     func testDebugFutureSuccessWithIdentifier() {

--- a/BrightFuturesTests/FutureDebugTests.swift
+++ b/BrightFuturesTests/FutureDebugTests.swift
@@ -1,0 +1,35 @@
+//
+//  FutureDebugTests.swift
+//  BrightFutures
+//
+//  Created by Oleksii on 23/09/2016.
+//  Copyright © 2016 Thomas Visser. All rights reserved.
+//
+
+import XCTest
+
+class FutureDebugTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testExample() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+    
+    func testPerformanceExample() {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+    
+}

--- a/BrightFuturesTests/FutureDebugTests.swift
+++ b/BrightFuturesTests/FutureDebugTests.swift
@@ -20,6 +20,7 @@ class TestLogger: LoggerType {
 
 class FutureDebugTests: XCTestCase {
     let testIdentifier = "testFutureIdentifier"
+    let error = NSError(domain: "test", code: 0, userInfo: nil)
     
     func testStringLastPathComponent() {
         XCTAssertEqual("/tmp/scratch.tiff".lastPathComponent, "scratch.tiff")
@@ -37,6 +38,19 @@ class FutureDebugTests: XCTestCase {
         
         f.onSuccess {
             XCTAssertEqual(logger.lastLoggedMessage, "Future \(self.testIdentifier) succeeded")
+            debugExpectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 2, handler: nil)
+    }
+    
+    func testDebugFutureFailureWithIdentifier() {
+        let logger = TestLogger()
+        let f = Future<Void, NSError>(error: error).debug(testIdentifier, logger: logger)
+        let debugExpectation = self.expectation(description: "debugLogged")
+        
+        f.onFailure { _ in
+            XCTAssertEqual(logger.lastLoggedMessage, "Future \(self.testIdentifier) failed")
             debugExpectation.fulfill()
         }
         

--- a/BrightFuturesTests/FutureDebugTests.swift
+++ b/BrightFuturesTests/FutureDebugTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+import Result
 @testable import BrightFutures
 
 class TestLogger: LoggerType {
@@ -18,6 +19,7 @@ class TestLogger: LoggerType {
 }
 
 class FutureDebugTests: XCTestCase {
+    let testIdentifier = "testFutureIdentifier"
     
     func testStringLastPathComponent() {
         XCTAssertEqual("/tmp/scratch.tiff".lastPathComponent, "scratch.tiff")
@@ -27,4 +29,17 @@ class FutureDebugTests: XCTestCase {
         XCTAssertEqual("/".lastPathComponent, "/")
     }
     
+    func testDebugFutureSuccessWithIdentifier() {
+        let logger = TestLogger()
+        
+        let f = Future<Void, NoError>(value: ()).debug(testIdentifier, logger: logger)
+        let debugExpectation = self.expectation(description: "debugLogged")
+        
+        f.onSuccess {
+            XCTAssertEqual(logger.lastLoggedMessage, "Future \(self.testIdentifier) succeeded")
+            debugExpectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 2, handler: nil)
+    }
 }

--- a/BrightFuturesTests/FutureDebugTests.swift
+++ b/BrightFuturesTests/FutureDebugTests.swift
@@ -7,29 +7,16 @@
 //
 
 import XCTest
+@testable import BrightFutures
 
 class FutureDebugTests: XCTestCase {
     
-    override func setUp() {
-        super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-    
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
-    }
-    
-    func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
-    
-    func testPerformanceExample() {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
+    func testStringLastPathComponent() {
+        XCTAssertEqual("/tmp/scratch.tiff".lastPathComponent, "scratch.tiff")
+        XCTAssertEqual("/tmp/scratch".lastPathComponent, "scratch")
+        XCTAssertEqual("/tmp/".lastPathComponent, "tmp")
+        XCTAssertEqual("scratch///".lastPathComponent, "scratch")
+        XCTAssertEqual("/".lastPathComponent, "/")
     }
     
 }


### PR DESCRIPTION
This pull request adds possibility to debug the results of `AsyncType`.

`AsyncType` can be logged in 2 ways:

1. By providing identifier and the log message with be generated automatically
2. By providing closure that will generate log message

What is more, I added `LoggerType` protocol for 2 reasons:

1. If someone would like to provide custom logger
2. To make unit testing nice and easy

I also created an internal extension on String to provide `lastPathComponent` as I didn't want to use `NSString`. All the test data for lastPathComponent is taken from [Apple Documentation](https://developer.apple.com/reference/foundation/nsstring/1416528-lastpathcomponent).

Hope to hear the feedback)