### PR TITLE
added @discardableResult to andThen

### DIFF
--- a/BrightFutures/AsyncType.swift
+++ b/BrightFutures/AsyncType.swift
@@ -82,6 +82,7 @@ public extension AsyncType {
     /// Adds the given closure as a callback for when this future completes.
     /// The closure is executed on the given context. If no context is given, the behavior is defined by the default threading model (see README.md)
     /// Returns a future that completes with the result from this future but only after executing the given closure
+    @discardableResult
     public func andThen(context c: @escaping ExecutionContext = DefaultThreadingModel(), callback: @escaping (Self.Value) -> Void) -> Self {
         return Self { complete in
             onComplete(c) { result in


### PR DESCRIPTION
We use `andThen` similar to `onSuccess` and `onFailure`, we believe it should also have the `@discardableResult` decorator.
