### PR TITLE
Add Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,12 @@
+import PackageDescription
+
+let package = Package(
+    name: "BrightFutures",
+    dependencies: [
+      .Package(
+        url: "https://github.com/antitypical/Result",
+        majorVersion: 3
+      )
+    ],
+    exclude: ["BrightFutures.xcworkspace", "BrightFutures.xcodeproj", "BrightFuturesTests", "Carthage", "Documentation"]
+)


### PR DESCRIPTION
BrightFutures needs two things to allow for swift's package manager to handle it gracefully:

- Use strict semver.org tags (https://github.com/apple/swift-package-manager/pull/341)
- Have a Package.swift in the root directory

This diff handles the second bullet but I believe the project owner would have to add a "5.0.1" tag alongside the current "v5.0.1".