### PR TITLE
Fixes swift 3.1 compile errors/warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ osx_image: xcode8
 
 script:
   - xcodebuild test -workspace BrightFutures.xcworkspace -scheme BrightFutures-Mac
-  - xcodebuild test -workspace BrightFutures.xcworkspace -scheme BrightFutures-iOS -sdk iphonesimulator
-  - xcodebuild test -workspace BrightFutures.xcworkspace -scheme BrightFutures-tvOS -sdk appletvsimulator
+  - xcodebuild test -workspace BrightFutures.xcworkspace -scheme BrightFutures-iOS -sdk iphonesimulator -destination "platform=iOS Simulator,OS=9.0,name=iPhone 6s"
+  - xcodebuild test -workspace BrightFutures.xcworkspace -scheme BrightFutures-tvOS -sdk appletvsimulator -destination "OS=9.0,name=Apple TV 1080p"
   - xcodebuild build -workspace BrightFutures.xcworkspace -scheme BrightFutures-watchOS -sdk watchsimulator
 
 notifications:

--- a/BrightFutures.podspec
+++ b/BrightFutures.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
 
   s.source_files = 'Sources/BrightFutures/*.swift'
 
-  s.dependency 'Result', '~> 3.0'
+  s.dependency 'Result', '~> 3.2'
 
   s.requires_arc = true
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "antitypical/Result" ~> 3.0.0
+github "antitypical/Result" ~> 3.2.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "antitypical/Result" "3.1.0"
+github "antitypical/Result" "3.2.1"

--- a/Sources/BrightFutures/Async.swift
+++ b/Sources/BrightFutures/Async.swift
@@ -143,7 +143,7 @@ extension Async: MutableAsyncType {
 
 extension Async: CustomStringConvertible, CustomDebugStringConvertible {
     public var description: String {
-        return "Async<\(Value.self)>(\(self.result))"
+        return "Async<\(Value.self)>(\(String(describing: self.result)))"
     }
     
     public var debugDescription: String {

--- a/Tests/BrightFuturesTests/BrightFuturesTests.swift
+++ b/Tests/BrightFuturesTests/BrightFuturesTests.swift
@@ -863,7 +863,7 @@ extension BrightFuturesTests {
     
     func testUtilsFirstCompleted() {
         let futures: [Future<Int, NoError>] = [
-            Future(value: 3, delay: 200.milliseconds),
+            Future(value: 3, delay: 500.milliseconds),
             Future(value: 13, delay: 300.milliseconds),
             Future(value: 23, delay: 400.milliseconds),
             Future(value: 4, delay: 300.milliseconds),


### PR DESCRIPTION
This fixes an issue where carthage would fail to build BrightFutures because `Result` version 3.0 was not compiled using swift 3.1.

I also update your podspec file but in the interest of full disclosure I did not test this to make sure it works with CocoaPods.