### PR TITLE
Explicit Void return type on `analysis(ifSuccess:` block

### DIFF
--- a/Sources/BrightFutures/Result+BrightFutures.swift
+++ b/Sources/BrightFutures/Result+BrightFutures.swift
@@ -46,7 +46,7 @@ extension ResultProtocol where Value: AsyncType, Value.Value: ResultProtocol, Er
     /// with the error from the outer result otherwise
     public func flatten() -> Future<Value.Value.Value, Value.Value.Error> {
         return Future { complete in
-            analysis(ifSuccess: { innerFuture in
+            analysis(ifSuccess: { innerFuture -> () in
                 innerFuture.onComplete(ImmediateExecutionContext) { res in
                     complete(res.analysis(ifSuccess: {
                         return Result(value: $0)


### PR DESCRIPTION
Fixes #183. The compile error in Xcode 9.3b4 is gone with this change, and it works in Xcode 9.2.

My understanding of https://bugs.swift.org/browse/SR-7059 is that Swift 4.1 is going to ship with this change being necessary.