### PR TITLE
Release 6.0.1

### DIFF
--- a/BrightFutures.podspec
+++ b/BrightFutures.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'BrightFutures'
-  s.version = '6.0.0'
+  s.version = '6.0.1'
   s.license = 'MIT'
   s.summary = 'Write great asynchronous code in Swift using futures and promises'
   s.homepage = 'https://github.com/Thomvis/BrightFutures'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 6.0.1
+Adds support for Swift 4.1 and Xcode 9.3 (tested with beta 4).
+
+- Workaround for [SR-7059](https://bugs.swift.org/browse/SR-7059)
+
 # 6.0.0
 Adds support for Swift 4 and Xcode 9
 


### PR DESCRIPTION
* Updated podspec and CHANGELOG for 6.0.1

Looks like the other steps to release a new version are tagging, creating a GitHub
release, and pushing an update to Cocoapods.

Anything else?