### PR TITLE
Fix the `andThen` test

### DIFF
--- a/Tests/BrightFuturesTests/BrightFuturesTests.swift
+++ b/Tests/BrightFuturesTests/BrightFuturesTests.swift
@@ -287,12 +287,12 @@ extension BrightFuturesTests {
             answer += 2
         }
         
-        f1.onSuccess { fval in
+        f.onSuccess { fval in
             f1.onSuccess { f1val in
                 f2.onSuccess { f2val in
                     
                     XCTAssertEqual(fval, f1val, "future value should be passed transparently")
-                    XCTAssertEqual(f1val, f2val, "future value should be passed transparantly")
+                    XCTAssertEqual(f1val, f2val, "future value should be passed transparently")
                     
                     e.fulfill()
                 }


### PR DESCRIPTION
There was one typo in the `f` future name next to the `.onSuccess` callback, and another in the assert error message.