### PR TITLE
Add earliest dispatch time functionality to AsyncType

### DIFF
--- a/Sources/BrightFutures/Async.swift
+++ b/Sources/BrightFutures/Async.swift
@@ -63,6 +63,13 @@ open class Async<Value>: AsyncType {
             self.complete(result)
         }
     }
+
+    /// Creates an `Async` that will be completed with the given result after the specified deadline
+    public required init(result: Value, earliest: DispatchTime) {
+        DispatchQueue.global().asyncAfter(deadline: earliest) {
+            self.complete(result)
+        }
+    }
     
     /// Creates an `Async` that is completed when the given other `Async` is completed
     public required init<A: AsyncType>(other: A) where A.Value == Value {

--- a/Sources/BrightFutures/AsyncType.swift
+++ b/Sources/BrightFutures/AsyncType.swift
@@ -78,6 +78,30 @@ public extension AsyncType {
             }
         }
     }
+
+    /// Alias of earliest(queue:interval:)
+    /// Will pass the main queue if we are currently on the main thread, or the
+    /// global queue otherwise
+    public func earliest(at deadline: DispatchTime) -> Self {
+        if Thread.isMainThread {
+            return earliest(DispatchQueue.main, at: deadline)
+        }
+
+        return earliest(DispatchQueue.global(), at: deadline)
+    }
+
+    /// Returns an Async that will complete with the result that this Async completes with
+    /// after waiting for the given deadline
+    /// The delay is implemented using dispatch_after. The given queue is passed to that function.
+    public func earliest(_ queue: DispatchQueue, at deadline: DispatchTime) -> Self {
+        return Self { complete in
+            onComplete(ImmediateExecutionContext) { result in
+                queue.asyncAfter(deadline: deadline) {
+                    complete(result)
+                }
+            }
+        }
+    }
     
     /// Adds the given closure as a callback for when this future completes.
     /// The closure is executed on the given context. If no context is given, the behavior is defined by the default threading model (see README.md)

--- a/Sources/BrightFutures/Future.swift
+++ b/Sources/BrightFutures/Future.swift
@@ -48,6 +48,10 @@ public final class Future<T, E: Error>: Async<Result<T, E>> {
     public init(value: T, delay: DispatchTimeInterval) {
         super.init(result: Result<T, E>(value: value), delay: delay)
     }
+
+    public init(value: T, earliest deadline: DispatchTime) {
+        super.init(result: Result<T, E>(value: value), earliest: deadline)
+    }
     
     public required init<A: AsyncType>(other: A) where A.Value == Value {
         super.init(other: other)
@@ -55,6 +59,10 @@ public final class Future<T, E: Error>: Async<Result<T, E>> {
     
     public required init(result: Value, delay: DispatchTimeInterval) {
         super.init(result: result, delay: delay)
+    }
+
+    public required init(result: Value, earliest deadline: DispatchTime) {
+        super.init(result: result, earliest: deadline)
     }
     
     public convenience init(value: T) {


### PR DESCRIPTION
This pull request adds the functionality to `AsyncType` to be dispatched earliest at the given deadline. This is similar to `delay()`. However instead of always waiting for a fixed interval, `earliest(at:)` will dispatch immediately if the deadline has already passed. In other words, `earliest(at:)` ensures a minimum time before the future completes.

**Motivation**
When using `BrightFutures` in combination with network requests, you can't know when the server will respond to your request. If you have some animations for such network requests (e.g. activity indicators), you want the user interface to behave in a smooth manner. This includes no rapid UI changes. With `earliest(at:)`, you can ensure that the user will at least catch a glimpse at the activity indicator when having a fast internet connection. On the other hand, there is no need for waiting an additonal interval when the network request returns after two seconds.

**Example**
```swift
spinner.startAnimation()
doNetworkTask().earliest(at: 500.milliseconds.fromNow).onComplete { _ in
    spinner.stopAnimation()
}
```