### PR TITLE
localThreadDictionary must be var

### DIFF
--- a/Sources/BrightFutures/ExecutionContext.swift
+++ b/Sources/BrightFutures/ExecutionContext.swift
@@ -47,7 +47,7 @@ public let MaxStackDepthExecutionContext: ExecutionContext = { task in
         static let maxTaskDepth = 20
     }
     
-    let localThreadDictionary = Thread.current.threadDictionary
+    var localThreadDictionary = Thread.current.threadDictionary
     
     var previousDepth: Int
     if let depth = localThreadDictionary[Static.taskDepthKey] as? Int {


### PR DESCRIPTION
This fixes a build error that occurs when building BrightFutures on Linux with Swift 4.2.3