### PR TITLE
Updated Package.swift to work with swift 5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,16 @@
+// swift-tools-version:5.0
 import PackageDescription
 
 let package = Package(
-    name: "BrightFutures"
+    name: "BrightFutures",
+    products: [
+        .library(
+            name: "BrightFutures",
+            targets: ["BrightFutures"]),
+    ],
+    targets: [
+        .target(
+            name: "BrightFutures",
+            dependencies: []),
+    ]
 )


### PR DESCRIPTION
Currently you cannot use version 8 with swift package manager v5. I updated the Package.swift file to build the library and specify swift tools version that allows use by swift5.