### PR TITLE
Fix Swift Version

### DIFF
--- a/BrightFutures.podspec
+++ b/BrightFutures.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
 
   s.requires_arc = true
 
-  s.swift_version = '5'
+  s.swift_version = '5.0'
 end


### PR DESCRIPTION
`s.swift_version = '5'` will produce `SWIFT_VERSION = 5;` in file `project.pxproj`, which keeps Xcode to prompt to convert to Swift 5.
Setting `s.swift_version = '5.0'` fix this issue.