### PR TITLE
Map by KeyPath

### DIFF
--- a/Sources/BrightFutures/AsyncType+ResultType.swift
+++ b/Sources/BrightFutures/AsyncType+ResultType.swift
@@ -87,10 +87,12 @@ public extension AsyncType where Value: ResultProtocol {
         return self.map(DefaultThreadingModel(), f: f)
     }
 
+    #if !swift(>=5.2)
     /// Similar to `func map<U>(_ f: @escaping (Value.Value) -> U) -> Future<U, Value.Error>`, but using `KeyPath` instead of a closure
     func map<U>(_ keyPath: KeyPath<Value.Value, U>) -> Future<U, Value.Error> {
         return self.map(DefaultThreadingModel(), keyPath: keyPath)
     }
+    #endif
 
     /// Returns a future that succeeds with the value returned from the given closure when it is invoked with the success value
     /// from this future. If this future fails, the returned future fails with the same error.
@@ -107,18 +109,12 @@ public extension AsyncType where Value: ResultProtocol {
         return res
     }
 
+    #if !swift(>=5.2)
     /// Similar to `func map<U>(_ context: @escaping ExecutionContext, f: @escaping (Value.Value) -> U) -> Future<U, Value.Error>`, but using `KeyPath` instead of a closure
     func map<U>(_ context: @escaping ExecutionContext, keyPath: KeyPath<Value.Value, U>) -> Future<U, Value.Error> {
-        let res = Future<U, Value.Error>()
-
-        self.onComplete(context, callback: { (result: Value) in
-            result.analysis(
-                ifSuccess: { res.success($0[keyPath: keyPath]) },
-                ifFailure: { res.failure($0) })
-        })
-
-        return res
+        return self.map { $0[keyPath: keyPath] }
     }
+    #endif
 
     /// Returns a future that completes with this future if this future succeeds or with the value returned from the given closure
     /// when it is invoked with the error that this future failed with.

--- a/Sources/BrightFutures/AsyncType+ResultType.swift
+++ b/Sources/BrightFutures/AsyncType+ResultType.swift
@@ -86,7 +86,12 @@ public extension AsyncType where Value: ResultProtocol {
     func map<U>(_ f: @escaping (Value.Value) -> U) -> Future<U, Value.Error> {
         return self.map(DefaultThreadingModel(), f: f)
     }
-    
+
+    /// Similar to `func map<U>(_ f: @escaping (Value.Value) -> U) -> Future<U, Value.Error>`, but using `KeyPath` instead of a closure
+    func map<U>(_ keyPath: KeyPath<Value.Value, U>) -> Future<U, Value.Error> {
+        return self.map(DefaultThreadingModel(), keyPath: keyPath)
+    }
+
     /// Returns a future that succeeds with the value returned from the given closure when it is invoked with the success value
     /// from this future. If this future fails, the returned future fails with the same error.
     /// The closure is executed on the given context. If no context is given, the behavior is defined by the default threading model (see README.md)
@@ -101,7 +106,20 @@ public extension AsyncType where Value: ResultProtocol {
         
         return res
     }
-    
+
+    /// Similar to `func map<U>(_ context: @escaping ExecutionContext, f: @escaping (Value.Value) -> U) -> Future<U, Value.Error>`, but using `KeyPath` instead of a closure
+    func map<U>(_ context: @escaping ExecutionContext, keyPath: KeyPath<Value.Value, U>) -> Future<U, Value.Error> {
+        let res = Future<U, Value.Error>()
+
+        self.onComplete(context, callback: { (result: Value) in
+            result.analysis(
+                ifSuccess: { res.success($0[keyPath: keyPath]) },
+                ifFailure: { res.failure($0) })
+        })
+
+        return res
+    }
+
     /// Returns a future that completes with this future if this future succeeds or with the value returned from the given closure
     /// when it is invoked with the error that this future failed with.
     /// The closure is executed on the given context. If no context is given, the behavior is defined by the default threading model (see README.md)

--- a/Tests/BrightFuturesTests/BrightFuturesTests.swift
+++ b/Tests/BrightFuturesTests/BrightFuturesTests.swift
@@ -357,6 +357,23 @@ extension BrightFuturesTests {
         self.waitForExpectations(timeout: 2, handler: nil)
     }
 
+    func testMapByKeyPath() {
+        struct S {
+            let a: Int
+        }
+
+        let e = self.expectation()
+
+        DispatchQueue.global().asyncValue {
+            S(a: 10)
+        }.map(\.a).onSuccess { keyPathValue in
+            XCTAssertEqual(keyPathValue, 10)
+            e.fulfill()
+        }
+
+        self.waitForExpectations(timeout: 2, handler: nil)
+    }
+
     func testRecover() {
         let e = self.expectation()
         Future<Int, TestError>(error: TestError.justAnError).recover { _ in


### PR DESCRIPTION
Hello.
Thank you for BrightFutures.
In this pull request I added `func map<U>(_ context: @escaping ExecutionContext, keyPath: KeyPath<Value.Value, U>) -> Future<U, Value.Error>`. It is similar to `map` that you already have, but accepts KeyPath instead of a closure.