### PR TITLE
Future.init(error: E, delay: DispatchTimeInterval)

### DIFF
--- a/Sources/BrightFutures/Future.swift
+++ b/Sources/BrightFutures/Future.swift
@@ -47,6 +47,10 @@ public final class Future<T, E: Error>: Async<Result<T, E>> {
     public init(value: T, delay: DispatchTimeInterval) {
         super.init(result: .success(value), delay: delay)
     }
+
+    public init(error: E, delay: DispatchTimeInterval) {
+        super.init(result: .failure(error), delay: delay)
+    }
     
     public required init<A: AsyncType>(other: A) where A.Value == Value {
         super.init(other: other)

--- a/Tests/BrightFuturesTests/BrightFuturesTests.swift
+++ b/Tests/BrightFuturesTests/BrightFuturesTests.swift
@@ -939,6 +939,7 @@ extension BrightFuturesTests {
         
         futures.firstCompleted().onSuccess { _ in
             XCTAssert(false)
+            e.fulfill()
         }.onFailure { error in
             switch error {
             case .justAnError:

--- a/Tests/BrightFuturesTests/BrightFuturesTests.swift
+++ b/Tests/BrightFuturesTests/BrightFuturesTests.swift
@@ -115,6 +115,29 @@ extension BrightFuturesTests {
         }
     }
     
+    func testFailedAfterFuture() {
+        let f = Future<Int, TestError>(error: .justAnError, delay: 1.second)
+        
+        XCTAssertFalse(f.isCompleted)
+        
+        Thread.sleep(forTimeInterval: 0.2)
+
+        XCTAssertFalse(f.isCompleted)
+        
+        Thread.sleep(forTimeInterval: 1.0)
+
+        XCTAssert(f.isCompleted)
+        
+        if let error = f.error {
+            switch error {
+            case .justAnError:
+                XCTAssert(true)
+            case .justAnotherError:
+                XCTAssert(false)
+            }
+        }
+    }
+    
     // this is inherently impossible to test, but we'll give it a try
     func testNeverCompletingFuture() {
         let f = Future<Int, Never>()
@@ -896,6 +919,33 @@ extension BrightFuturesTests {
         
         futures.firstCompleted().onSuccess { val in
             XCTAssertEqual(val, 9)
+            e.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 2, handler: nil)
+    }
+    
+    func testUtilsFirstCompletedWithError() {
+        let futures: [Future<Int, TestError>] = [
+            Future(value: 3, delay: 500.milliseconds),
+            Future(error: .justAnotherError, delay: 300.milliseconds),
+            Future(value: 23, delay: 400.milliseconds),
+            Future(value: 4, delay: 300.milliseconds),
+            Future(error: .justAnError, delay: 100.milliseconds),
+            Future(value: 83, delay: 400.milliseconds),
+        ]
+        
+        let e = self.expectation()
+        
+        futures.firstCompleted().onSuccess { _ in
+            XCTAssert(false)
+        }.onFailure { error in
+            switch error {
+            case .justAnError:
+                XCTAssert(true)
+            case .justAnotherError:
+                XCTAssert(false)
+            }
             e.fulfill()
         }
         


### PR DESCRIPTION
Hello.
Thank you for BrightFutures.
In this pull request I added `Future.init(error: E, delay: DispatchTimeInterval)`. This function is similar to `Future.init(value: T, delay: DispatchTimeInterval)`.