### PR TITLE
Reduce "warning: will never be executed"

### DIFF
--- a/Sources/BrightFutures/AsyncType+ResultType.swift
+++ b/Sources/BrightFutures/AsyncType+ResultType.swift
@@ -230,7 +230,18 @@ public extension AsyncType where Value: ResultProtocol, Value.Error == Never {
     /// for operations such as `sequence` and `firstCompleted`
     /// This is a safe operation, because a `Future` with error type `Never` is guaranteed never to fail
     func promoteError<E>() -> Future<Value.Value, E> {
-        return mapError(ImmediateExecutionContext) { $0 as! E } // future will never fail, so this map block will never get called
+        let res = Future<Value.Value, E>()
+        
+        self.onComplete(ImmediateExecutionContext) { result in
+            switch result.result {
+            case .success(let value):
+                res.success(value)
+            case .failure(let error):
+                return res.failure(error as! E) // future will never fail, so this cast will never get called
+            }
+        }
+        
+        return res
     }
 }
 
@@ -262,7 +273,18 @@ public extension AsyncType where Value: ResultProtocol, Value.Value == NoValue {
     /// for operations such as `sequence` and `firstCompleted`
     /// This is a safe operation, because a `Future` with value type `NoValue` is guaranteed never to succeed
     func promoteValue<T>() -> Future<T, Value.Error> {
-        return map(ImmediateExecutionContext) { $0 as! T } // future will never succeed, so this map block will never get called
+        let res = Future<T, Value.Error>()
+        
+        self.onComplete(ImmediateExecutionContext) { result in
+            switch result.result {
+            case .success(let value):
+                res.success(value as! T) // future will never succeed, so this cast will never get called
+            case .failure(let error):
+                return res.failure(error)
+            }
+        }
+        
+        return res
     }
 }
 


### PR DESCRIPTION
```sh
% swift -version
Apple Swift version 5.4 (swiftlang-1205.0.26.9 clang-1205.0.19.55)
Target: x86_64-apple-darwin20.4.0
```

```sh
% swift build
BrightFutures/Sources/BrightFutures/AsyncType+ResultType.swift:233:54: warning: will never be executed
        return mapError(ImmediateExecutionContext) { $0 as! E } // future will never fail, so this map block will never get called
                                                     ^
BrightFutures/Sources/BrightFutures/AsyncType+ResultType.swift:233:52: note: '$0' is uninhabited, so this function body can never be executed
        return mapError(ImmediateExecutionContext) { $0 as! E } // future will never fail, so this map block will never get called
                                                   ^
BrightFutures/Sources/BrightFutures/AsyncType+ResultType.swift:265:49: warning: will never be executed
        return map(ImmediateExecutionContext) { $0 as! T } // future will never succeed, so this map block will never get called
                                                ^
BrightFutures/Sources/BrightFutures/AsyncType+ResultType.swift:265:47: note: '$0' is uninhabited, so this function body can never be executed
        return map(ImmediateExecutionContext) { $0 as! T } // future will never succeed, so this map block will never get called
                                              ^
BrightFutures/Sources/BrightFutures/AsyncType+ResultType.swift:233:54: warning: will never be executed
        return mapError(ImmediateExecutionContext) { $0 as! E } // future will never fail, so this map block will never get called
                                                     ^
BrightFutures/Sources/BrightFutures/AsyncType+ResultType.swift:233:52: note: '$0' is uninhabited, so this function body can never be executed
        return mapError(ImmediateExecutionContext) { $0 as! E } // future will never fail, so this map block will never get called
                                                   ^
BrightFutures/Sources/BrightFutures/AsyncType+ResultType.swift:265:49: warning: will never be executed
        return map(ImmediateExecutionContext) { $0 as! T } // future will never succeed, so this map block will never get called
                                                ^
BrightFutures/Sources/BrightFutures/AsyncType+ResultType.swift:265:47: note: '$0' is uninhabited, so this function body can never be executed
        return map(ImmediateExecutionContext) { $0 as! T } // future will never succeed, so this map block will never get called
                                              ^
[17/17] Merging module BrightFutures
```

There is no way in Swift to suppress a warning on a line of code. This patch is not as clean as original functional code, but the warnings go away.